### PR TITLE
Create integration pipeline index

### DIFF
--- a/integrations/index.md
+++ b/integrations/index.md
@@ -1,0 +1,34 @@
+# Integration Pipelines Index
+Tags: [index], [integration]
+
+## Summary
+Integrating Post Singularity lore with AI-driven production flows keeps the emotional core intact across formats like episodic video, interactive games, and print.
+
+## Function
+This index introduces upcoming guides for turning PS stories into repeatable AI-enabled pipelines.
+
+## Cultural Effects
+A shared toolkit encourages cross-medium collaboration and experimentation.
+
+## Philosophical Tensions
+How much automation can a human-centered world tolerate?
+
+## Story Use
+Follow these guides to adapt lore or characters for new experiences.
+
+### Guides
+- [Episode Pipeline](episode-pipeline.md)
+- [Game Pipeline](game-pipeline.md)
+- [Print Pipeline](print-pipeline.md)
+
+```json
+{
+  "id": "integration_index",
+  "type": "reference",
+  "name": "Integration Pipelines Index",
+  "tags": ["integration"],
+  "introduced_in_cycle": 0,
+  "related_characters": [],
+  "impact": ["production links", "cross-medium"]
+}
+```


### PR DESCRIPTION
## Summary
- add new `integrations/` directory
- create `index.md` for planned AI-driven media pipeline docs

## Testing
- `python3 scripts/validate_metadata.py integrations/index.md`
- `python3 scripts/validate_metadata.py`

------
https://chatgpt.com/codex/tasks/task_e_6840b22a65dc832e8ed99bdc4e5b3412