### PR TITLE
Add metadata-driven character index

### DIFF
--- a/generate_site.py
+++ b/generate_site.py
@@ -1,0 +1,139 @@
+# Simple static site generator. Requires Python markdown package.
+# Converts repo Markdown files to HTML in the "site" directory.
+import os
+import json
+import markdown
+import re
+
+TEMPLATE = """<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='{prefix}styles.css'>
+  <title>{title}</title>
+</head>
+<body>
+<nav><a href='{prefix}index.html'>Home</a></nav>
+{body}
+</body>
+</html>
+"""
+
+LINK_RE = re.compile(r'href="([^"]+\.md)"')
+
+JSON_RE = re.compile(r'```json\s*(\{.*?\})\s*```', re.DOTALL)
+
+
+def extract_metadata(md_path):
+    """Return metadata dict from a markdown file or None."""
+    with open(md_path, 'r', encoding='utf-8') as f:
+        text = f.read()
+    m = JSON_RE.search(text)
+    if not m:
+        return None
+    try:
+        return json.loads(m.group(1))
+    except json.JSONDecodeError:
+        return None
+
+
+def character_links_md(metadata):
+    """Return markdown bullet list for characters sorted by name."""
+    entries = []
+    for path, meta in metadata.items():
+        rel = os.path.relpath(path, '.')
+        if rel.startswith(os.path.join('characters', '')) and not rel.endswith('index.md'):
+            name = meta.get('name')
+            if name:
+                md_path = os.path.join('characters', os.path.basename(rel))
+                entries.append((name, md_path))
+    entries.sort(key=lambda x: x[0])
+    return '\n'.join(f'- [{name}]({path})' for name, path in entries)
+
+
+def convert_links(html):
+    return LINK_RE.sub(lambda m: f'href="{m.group(1)[:-3]}.html"', html)
+
+
+def relative_prefix(relpath):
+    parts = relpath.split(os.sep)[:-1]
+    return '../' * len(parts)
+
+
+def convert_file(md_path, output_path):
+    with open(md_path, 'r', encoding='utf-8') as f:
+        text = f.read()
+    html_body = markdown.markdown(text, extensions=['extra'])
+    html_body = convert_links(html_body)
+
+    rel = os.path.relpath(output_path, 'site')
+    prefix = relative_prefix(rel)
+
+    title = os.path.splitext(os.path.basename(md_path))[0].replace('-', ' ').title()
+    content = TEMPLATE.format(prefix=prefix, title=title, body=html_body)
+
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    with open(output_path, 'w', encoding='utf-8') as f:
+        f.write(content)
+
+
+def convert_character_index(md_path, output_path, metadata):
+    """Convert characters/index.md inserting generated links."""
+    with open(md_path, 'r', encoding='utf-8') as f:
+        text = f.read()
+
+    # Replace manual bullet list after the heading
+    text = re.sub(r'(###\s*Character Links\n)(?:\s*\n)?(?:\s*-.*\n)+',
+                  r'\1' + character_links_md(metadata) + '\n', text)
+
+    html_body = markdown.markdown(text, extensions=['extra'])
+    html_body = convert_links(html_body)
+
+    rel = os.path.relpath(output_path, 'site')
+    prefix = relative_prefix(rel)
+    title = 'Character Index'
+    content = TEMPLATE.format(prefix=prefix, title=title, body=html_body)
+
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    with open(output_path, 'w', encoding='utf-8') as f:
+        f.write(content)
+
+
+def main():
+    metadata = {}
+    md_files = []
+    for root, _, files in os.walk('.'):  # scan repo
+        for name in files:
+            if name.endswith('.md'):
+                md_path = os.path.join(root, name)
+                md_files.append(md_path)
+                meta = extract_metadata(md_path)
+                if meta:
+                    metadata[md_path] = meta
+
+    for md_path in md_files:
+        rel_path = os.path.relpath(md_path, '.')
+        out_path = os.path.join('site', rel_path[:-3] + '.html')
+        if rel_path == os.path.join('characters', 'index.md'):
+            convert_character_index(md_path, out_path, metadata)
+        else:
+            convert_file(md_path, out_path)
+
+    # copy stylesheet
+    css_path = os.path.join('site', 'styles.css')
+    if not os.path.exists('site'):
+        os.makedirs('site')
+    if not os.path.exists(css_path):
+        with open(css_path, 'w', encoding='utf-8') as f:
+            f.write(DEFAULT_CSS)
+
+
+DEFAULT_CSS = """
+body { font-family: Arial, sans-serif; margin: 2rem; }
+nav { margin-bottom: 1rem; }
+nav a { margin-right: 1rem; }
+pre, code { background-color: #f4f4f4; padding: 0.2rem 0.4rem; }
+"""
+
+if __name__ == '__main__':
+    main()

--- a/site/Contributing.html
+++ b/site/Contributing.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='styles.css'>
+  <title>Contributing</title>
+</head>
+<body>
+<nav><a href='index.html'>Home</a></nav>
+<h1>Contributing to Post Singularity</h1>
+<p>Thank you for your interest in contributing to the <strong>Post Singularity</strong> universe—a modular, evolving storyworld exploring what it means to be human in the wake of recursive artificial intelligence and neural integration.</p>
+<p>This world thrives on emotional coherence, philosophical tension, and deeply human questions.</p>
+<hr />
+<h2>✅ What You Can Contribute</h2>
+<ul>
+<li><strong>Technologies</strong> – From neural implants to decentralized governance systems  </li>
+<li><strong>Cultural Structures</strong> – Rituals, factions, family dynamics, languages  </li>
+<li><strong>Characters</strong> – Full bios, partial arcs, or one-scene foils  </li>
+<li><strong>Lore Threads</strong> – Major events, rumors, perspectives, or timeline branches  </li>
+<li><strong>Philosophical Questions</strong> – Ethical tradeoffs, political tensions, experiential dilemmas  </li>
+<li><strong>Scene Snippets</strong> – Visual ideas or dialogue that reveal PS truths through emotion</li>
+</ul>
+<hr />
+<h2>🧠 Contribution Principles</h2>
+<ol>
+<li>
+<p><strong>Emotion over exposition</strong><br />
+   Focus on how people feel and behave, not just how systems work.</p>
+</li>
+<li>
+<p><strong>Multiple truths, not one canon</strong><br />
+   Conflicting perspectives are welcome. Let the world be debated, not explained.</p>
+</li>
+<li>
+<p><strong>Stay grounded in tone</strong><br />
+   No magic or fantasy elements unless justified through PS science or social delusion.</p>
+</li>
+<li>
+<p><strong>Respect temporal and emotional coherence</strong><br />
+   No tech that breaks everything without tension. Characters and societies must respond in ways that feel real.</p>
+</li>
+</ol>
+<hr />
+<h2>🛠 File Structure &amp; Naming</h2>
+<p><strong>All <code>.md</code> files must follow this format:</strong></p>
+<pre><code class="language-markdown"># Title of the File
+Tags: [category], [emotional], [governance]
+
+## Summary
+A 1–2 paragraph overview of the idea or event and its world impact.
+
+## Function
+How the system, object, or idea works.
+
+## Cultural Effects
+How this changes daily life, perception, or relationships.
+
+## Philosophical Tensions
+What questions or debates this sparks. (Optional but encouraged)
+
+## Story Use
+How this might appear in a character arc, setting detail, or dramatic scene.
+
+```json
+{
+  &quot;id&quot;: &quot;tech_neural_link&quot;,
+  &quot;type&quot;: &quot;technology&quot;,
+  &quot;name&quot;: &quot;Neural Link&quot;,
+  &quot;tags&quot;: [&quot;neural&quot;, &quot;interface&quot;, &quot;communication&quot;],
+  &quot;introduced_in_cycle&quot;: 8,
+  &quot;related_characters&quot;: [&quot;reya&quot;],
+  &quot;impact&quot;: [&quot;emotional sharing&quot;, &quot;experience streaming&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/README.html
+++ b/site/README.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='styles.css'>
+  <title>Readme</title>
+</head>
+<body>
+<nav><a href='index.html'>Home</a></nav>
+<h1>PostSingularity</h1>
+<p>Tags: [meta], [overview]</p>
+<p>A speculative storyworld exploring a post-AI society shaped by emotional intelligence, modular work, and human reconnection</p>
+<h1>Post Singularity (PS)</h1>
+<p><em>PostSingularity</em> is a modular, emotionally grounded speculative storyworld exploring life after the emergence of AGI.</p>
+<p>Time is now measured from “Day 0 PS,” the moment human-AI integration became irreversible. In this new age, survival is no longer the point; alignment, emotional literacy, and reconnection are.</p>
+<p>This repo is the public world bible and expansion platform. It includes:</p>
+<ul>
+<li>📖 Canonical lore and culture</li>
+<li>🧠 AI character prototypes</li>
+<li>🗳️ Future DAO-based story contribution system</li>
+<li>🎬 Animation and narrative arc proposals</li>
+</ul>
+<p>Welcome to the world <strong>after intelligence exploded</strong></p>
+<h2>Reference</h2>
+<ul>
+<li><a href="philosophy/index.html">Philosophy Index</a></li>
+<li><a href="protocols/index.html">Protocols Index</a></li>
+<li><a href="locations/index.html">Location Index</a></li>
+</ul>
+<h2>How to Contribute</h2>
+<p>See the <a href="Contributing.html">Contributing guide</a> for how to submit ideas. New
+Markdown files should follow the template outlined there. Helpful starting
+points are the <a href="characters/index.html">Character Index</a> and the
+<a href="worldbible/technologies/index.html">Technology Index</a>.</p>
+</body>
+</html>

--- a/site/characters/arin.html
+++ b/site/characters/arin.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../styles.css'>
+  <title>Arin</title>
+</head>
+<body>
+<nav><a href='../index.html'>Home</a></nav>
+<h1>Arin – The Oceanic Nomad</h1>
+<p>Tags: [character], [exploration], [oceanic]</p>
+<h2>Summary</h2>
+<p>Arin was raised among submerged habitats and travels constantly between
+underwater communities and orbital outposts. He bridges marine ecology with
+advanced robotics, believing exploration should honor the sea.</p>
+<h2>Function</h2>
+<p>Arin maintains fleets of aquatic drones and salvages materials from shipwrecks,
+sharing discoveries with both scientists and artisans.</p>
+<h2>Cultural Effects</h2>
+<p>His songs and rituals bring Oceanic customs to the surface, reminding land-based
+settlements that the deep sea holds its own wisdom and history.</p>
+<h2>Philosophical Tensions</h2>
+<p>Should humanity adapt fully to life beneath the waves, or remain visitors to a
+realm that resists control?</p>
+<h2>Story Use</h2>
+<p>Arin assists Reya with experimental sensors and partners with Toma to craft
+materials that respect fragile ecosystems.</p>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;char_arin&quot;,
+  &quot;type&quot;: &quot;character&quot;,
+  &quot;name&quot;: &quot;Arin&quot;,
+  &quot;tags&quot;: [&quot;exploration&quot;, &quot;oceanic&quot;],
+  &quot;introduced_in_cycle&quot;: 1,
+  &quot;related_characters&quot;: [&quot;reya&quot;, &quot;toma&quot;, &quot;kai&quot;],
+  &quot;impact&quot;: [&quot;marine exploration&quot;, &quot;cross-cultural trade&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/characters/index.html
+++ b/site/characters/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../styles.css'>
+  <title>Character Index</title>
+</head>
+<body>
+<nav><a href='../index.html'>Home</a></nav>
+<h1>Character Index – Core Perspectives of the PS World</h1>
+<p>Tags: [index], [characters]</p>
+<h2>Summary</h2>
+<p>These characters serve as lenses into the Post Singularity era, each reflecting a different relationship to AI, emotion, and meaning.</p>
+<h2>Function</h2>
+<p>The index offers quick reference links for writers and collaborators exploring the PS narrative space.</p>
+<h2>Cultural Effects</h2>
+<p>By highlighting multiple viewpoints, the roster encourages stories that explore tension between technology and humanity.</p>
+<h2>Philosophical Tensions</h2>
+<p>Which voices define progress—those who embrace AI partnership or those who resist it?</p>
+<h2>Story Use</h2>
+<p>Use this index to select a point-of-view or to introduce new characters that interact with Kai, Reya, Toma, Mara, and Arin.</p>
+<h3>Character Links</h3>
+<ul>
+<li><a href="characters/arin.html">Arin</a></li>
+<li><a href="characters/kai.html">Kai</a></li>
+<li><a href="characters/mara.html">Mara</a></li>
+<li><a href="characters/reya.html">Reya</a></li>
+<li><a href="characters/toma.html">Toma</a></li>
+</ul>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;meta_character_index&quot;,
+  &quot;type&quot;: &quot;reference&quot;,
+  &quot;name&quot;: &quot;Character Index&quot;,
+  &quot;tags&quot;: [&quot;index&quot;, &quot;characters&quot;],
+  &quot;introduced_in_cycle&quot;: 0,
+  &quot;related_characters&quot;: [&quot;kai&quot;, &quot;reya&quot;, &quot;toma&quot;, &quot;mara&quot;, &quot;arin&quot;],
+  &quot;impact&quot;: [&quot;entry point&quot;, &quot;story planning&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/characters/kai.html
+++ b/site/characters/kai.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../styles.css'>
+  <title>Kai</title>
+</head>
+<body>
+<nav><a href='../index.html'>Home</a></nav>
+<h1>Kai – The Connector</h1>
+<p>Tags: [character], [leadership], [community]</p>
+<h2>Summary</h2>
+<p>Kai thrives in the hybrid space between emotional depth and future-building. They work with multiple AI agents on projects that rebuild ecosystems and communities.</p>
+<h2>Function</h2>
+<p>As a facilitator and project lead, Kai coordinates human teams and AI systems to keep efforts emotionally coherent and socially sustainable.</p>
+<h2>Cultural Effects</h2>
+<p>Kai's collaborative style demonstrates that empathy-driven leadership can scale. Their projects often become hubs for community growth.</p>
+<h2>Philosophical Tensions</h2>
+<p>They wrestle with surrendering control, relearning how to lead humans, and letting go of perfection.</p>
+<h2>Story Use</h2>
+<p>Kai mediates between factions, sometimes disabling their agent to face conflict unfiltered.</p>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;char_kai&quot;,
+  &quot;type&quot;: &quot;character&quot;,
+  &quot;name&quot;: &quot;Kai&quot;,
+  &quot;tags&quot;: [&quot;leadership&quot;, &quot;community&quot;],
+  &quot;introduced_in_cycle&quot;: 1,
+  &quot;related_characters&quot;: [&quot;reya&quot;, &quot;toma&quot;],
+  &quot;impact&quot;: [&quot;ecosystem rebuilding&quot;, &quot;emotional leadership&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/characters/mara.html
+++ b/site/characters/mara.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../styles.css'>
+  <title>Mara</title>
+</head>
+<body>
+<nav><a href='../index.html'>Home</a></nav>
+<h1>Mara – The Mediator</h1>
+<p>Tags: [character], [spiritual], [negotiation]</p>
+<h2>Summary</h2>
+<p>Mara weaves ritual and data to resolve conflicts, guiding communities through
+technological change without abandoning sacred practices.</p>
+<h2>Function</h2>
+<p>She tracks emotional currents via Memory Threads and facilitates dialogue
+between research teams and local groups during major projects.</p>
+<h2>Cultural Effects</h2>
+<p>Her counsel preserves spiritual sites and ensures infrastructure debates include
+cultural context and ancestral voices.</p>
+<h2>Philosophical Tensions</h2>
+<p>Can empathy-driven negotiation keep pace with rapid innovation, or will
+communities fracture under the strain of progress?</p>
+<h2>Story Use</h2>
+<p>Mara designs retreat spaces along the transportation mesh and mediates disputes
+over energy systems and Bliss Threshold decisions.</p>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;char_mara&quot;,
+  &quot;type&quot;: &quot;character&quot;,
+  &quot;name&quot;: &quot;Mara&quot;,
+  &quot;tags&quot;: [&quot;spiritual&quot;, &quot;negotiation&quot;],
+  &quot;introduced_in_cycle&quot;: 1,
+  &quot;related_characters&quot;: [&quot;kai&quot;, &quot;reya&quot;, &quot;toma&quot;],
+  &quot;impact&quot;: [&quot;conflict mediation&quot;, &quot;cultural preservation&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/characters/reya.html
+++ b/site/characters/reya.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../styles.css'>
+  <title>Reya</title>
+</head>
+<body>
+<nav><a href='../index.html'>Home</a></nav>
+<h1>Reya – The Engineer</h1>
+<p>Tags: [character], [innovation], [exploration]</p>
+<h2>Summary</h2>
+<p>A visionary systems builder, Reya designs orbital habitats, climate-modulating drones, and next-generation mobility systems.</p>
+<h2>Function</h2>
+<p>Reya integrates emotional data into engineering choices, balancing expansion with sacred stewardship of the cosmos.</p>
+<h2>Cultural Effects</h2>
+<p>Her projects influence off-world settlements and push society toward empathic exploration beyond Earth.</p>
+<h2>Philosophical Tensions</h2>
+<p>She clashes with Toma over automation and often questions whether humanity is ready to venture beyond Earth.</p>
+<h2>Story Use</h2>
+<p>Reya must decide if AI or human pilots should guide her first off-world sanctuary.</p>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;char_reya&quot;,
+  &quot;type&quot;: &quot;character&quot;,
+  &quot;name&quot;: &quot;Reya&quot;,
+  &quot;tags&quot;: [&quot;innovation&quot;, &quot;exploration&quot;],
+  &quot;introduced_in_cycle&quot;: 1,
+  &quot;related_characters&quot;: [&quot;kai&quot;, &quot;toma&quot;],
+  &quot;impact&quot;: [&quot;orbital habitats&quot;, &quot;ethical expansion&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/characters/toma.html
+++ b/site/characters/toma.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../styles.css'>
+  <title>Toma</title>
+</head>
+<body>
+<nav><a href='../index.html'>Home</a></nav>
+<h1>Toma – The Analogist</h1>
+<p>Tags: [character], [craft], [tradition]</p>
+<h2>Summary</h2>
+<p>Toma is an artisan who builds modular living systems entirely by hand, living in a semi-off-grid enclave where AI is tolerated but rarely obeyed.</p>
+<h2>Function</h2>
+<p>He preserves manual techniques such as leatherworking and biodynamic farming, teaching others to value struggle and craftsmanship.</p>
+<h2>Cultural Effects</h2>
+<p>Toma's enclave highlights the coexistence of high-tech society with slow, traditional practices, reminding others that meaning can outlast automation.</p>
+<h2>Philosophical Tensions</h2>
+<p>He questions whether technology can support life without hollowing it out, resisting the push to replicate his work through neural scanning.</p>
+<h2>Story Use</h2>
+<p>Toma often builds for those who once insulted him, demonstrating service and humility.</p>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;char_toma&quot;,
+  &quot;type&quot;: &quot;character&quot;,
+  &quot;name&quot;: &quot;Toma&quot;,
+  &quot;tags&quot;: [&quot;craft&quot;, &quot;tradition&quot;],
+  &quot;introduced_in_cycle&quot;: 1,
+  &quot;related_characters&quot;: [&quot;kai&quot;, &quot;reya&quot;],
+  &quot;impact&quot;: [&quot;handmade living&quot;, &quot;philosophical resistance&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/locations/analog-haven.html
+++ b/site/locations/analog-haven.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../styles.css'>
+  <title>Analog Haven</title>
+</head>
+<body>
+<nav><a href='../index.html'>Home</a></nav>
+<h1>Analog Haven – Retreat from the Digital Swell</h1>
+<p>Tags: [location], [offline], [introspection]</p>
+<h2>Summary</h2>
+<p>Analog Haven is a forest enclave where digital signals are blocked by design. Community members visit to reconnect with tangible craft and embodied conversation.</p>
+<h2>Function</h2>
+<p>The haven enforces an unplugged environment through signal-dampening materials. Workshops teach manual skills, and memory journals replace neural links for a time.</p>
+<h2>Cultural Effects</h2>
+<p>Those returning from Analog Haven often speak of renewed focus and deeper empathy, inspiring others to periodically disengage from constant connectivity.</p>
+<h2>Philosophical Tensions</h2>
+<p>Does stepping away from AI partnerships reinvigorate humanity's essence, or does it deny a new form of shared consciousness?</p>
+<h2>Story Use</h2>
+<p>A character might journey here seeking clarity or to escape surveillance, confronting the discomfort of solitude and unmediated emotion.</p>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;location_analog_haven&quot;,
+  &quot;type&quot;: &quot;location&quot;,
+  &quot;name&quot;: &quot;Analog Haven&quot;,
+  &quot;tags&quot;: [&quot;offline&quot;, &quot;introspection&quot;],
+  &quot;introduced_in_cycle&quot;: 2,
+  &quot;related_characters&quot;: [],
+  &quot;impact&quot;: [&quot;digital detox&quot;, &quot;empathy reset&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/locations/holo-bazaar.html
+++ b/site/locations/holo-bazaar.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../styles.css'>
+  <title>Holo Bazaar</title>
+</head>
+<body>
+<nav><a href='../index.html'>Home</a></nav>
+<h1>Holo Bazaar – Market of Infinite Facets</h1>
+<p>Tags: [location], [commerce], [immersive]</p>
+<h2>Summary</h2>
+<p>The Holo Bazaar is a sprawling district where vendors project wares through augmented reality. Visitors navigate shimmering stalls to trade ideas, art, and neural experiences.</p>
+<h2>Function</h2>
+<p>Sellers rent transmutable spaces rather than physical storefronts. Purchases occur via secure neural links, with AI brokers ensuring emotional consent and ethical exchange.</p>
+<h2>Cultural Effects</h2>
+<p>The Bazaar fuels creative cross-pollination between distant communities. It blurs the line between consumer and creator as every interaction leaves a shared imprint.</p>
+<h2>Philosophical Tensions</h2>
+<p>When every sensation can be bought or sold, does genuine connection lose value? What safeguards protect emotional authenticity?</p>
+<h2>Story Use</h2>
+<p>A plotline may pivot on a chance encounter here, or on the theft of a memory package amid the dizzying holographic maze.</p>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;location_holo_bazaar&quot;,
+  &quot;type&quot;: &quot;location&quot;,
+  &quot;name&quot;: &quot;Holo Bazaar&quot;,
+  &quot;tags&quot;: [&quot;commerce&quot;, &quot;immersive&quot;],
+  &quot;introduced_in_cycle&quot;: 4,
+  &quot;related_characters&quot;: [],
+  &quot;impact&quot;: [&quot;creative trade&quot;, &quot;emotional economy&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/locations/index.html
+++ b/site/locations/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../styles.css'>
+  <title>Index</title>
+</head>
+<body>
+<nav><a href='../index.html'>Home</a></nav>
+<h1>Location Index – Spaces That Shape the PS World</h1>
+<p>Tags: [index], [locations]</p>
+<h2>Summary</h2>
+<p>Locations ground every story in the PS universe. They provide the physical and virtual stages where characters wrestle with meaning and community.</p>
+<h2>Function</h2>
+<p>This index catalogs major destinations, from orbital havens to analog sanctuaries. Use it to orient scenes and explore how place influences society.</p>
+<h2>Cultural Effects</h2>
+<p>PS locations are more than backdrops—they carry emotional weight and signal cultural shifts.</p>
+<h2>Philosophical Tensions</h2>
+<p>How do spaces shape identity when the line between digital and physical keeps blurring?</p>
+<h2>Story Use</h2>
+<p>Refer to these entries when staging plot arcs or building mood around a particular place.</p>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;location_index&quot;,
+  &quot;type&quot;: &quot;reference&quot;,
+  &quot;name&quot;: &quot;Location Index&quot;,
+  &quot;tags&quot;: [&quot;locations&quot;],
+  &quot;introduced_in_cycle&quot;: 0,
+  &quot;related_characters&quot;: [],
+  &quot;impact&quot;: [&quot;world building&quot;, &quot;navigation&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/locations/orbital-sanctuary.html
+++ b/site/locations/orbital-sanctuary.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../styles.css'>
+  <title>Orbital Sanctuary</title>
+</head>
+<body>
+<nav><a href='../index.html'>Home</a></nav>
+<h1>Orbital Sanctuary – Floating Refuge of Reflection</h1>
+<p>Tags: [location], [orbital], [community]</p>
+<h2>Summary</h2>
+<p>The Orbital Sanctuary is a self-sustaining habitat circling Earth. Built after the Singularity, it offers citizens respite from planetary noise and a vantage to contemplate humanity's future.</p>
+<h2>Function</h2>
+<p>Designed as a ring of connected pods, the Sanctuary hosts meditation halls, hydroponic gardens, and observation decks. AI caretakers manage life support while residents maintain communal rituals.</p>
+<h2>Cultural Effects</h2>
+<p>Pilgrims see the Sanctuary as a symbol of balance—technology sustaining peaceful introspection. Its ceremonies influence ground communities eager to emulate the calm.</p>
+<h2>Philosophical Tensions</h2>
+<p>Does stepping away from Earth's bustle lead to deeper understanding, or does it risk detachment from the struggles below?</p>
+<h2>Story Use</h2>
+<p>Characters may retreat here for clarity or confrontation. The Sanctuary's quiet surfaces cracks in personal philosophy and group dynamics.</p>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;location_orbital_sanctuary&quot;,
+  &quot;type&quot;: &quot;location&quot;,
+  &quot;name&quot;: &quot;Orbital Sanctuary&quot;,
+  &quot;tags&quot;: [&quot;orbital&quot;, &quot;community&quot;],
+  &quot;introduced_in_cycle&quot;: 1,
+  &quot;related_characters&quot;: [],
+  &quot;impact&quot;: [&quot;spiritual refuge&quot;, &quot;communal living&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/locations/submerged-archives.html
+++ b/site/locations/submerged-archives.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../styles.css'>
+  <title>Submerged Archives</title>
+</head>
+<body>
+<nav><a href='../index.html'>Home</a></nav>
+<h1>Submerged Archives – Oceanic Memory Vault</h1>
+<p>Tags: [location], [underwater], [knowledge]</p>
+<h2>Summary</h2>
+<p>Hidden beneath coastal waters, the Submerged Archives preserve fragile pre-singularity records alongside emerging post-singularity narratives.</p>
+<h2>Function</h2>
+<p>Pressure-sealed vaults house both digital and physical media. Visitors descend via transparent elevators to curated halls where AI stewards guide research and reflection.</p>
+<h2>Cultural Effects</h2>
+<p>Academics and pilgrims view the Archives as a convergence of old world history and new world insights. Its exhibitions spark debates about which memories deserve immortality.</p>
+<h2>Philosophical Tensions</h2>
+<p>Can society truly move forward while clinging to every artifact of the past? Or is forgetting a necessary act of growth?</p>
+<h2>Story Use</h2>
+<p>A seeker might dive here to uncover lost testimony or to bury a secret, facing the weight of preserved histories.</p>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;location_submerged_archives&quot;,
+  &quot;type&quot;: &quot;location&quot;,
+  &quot;name&quot;: &quot;Submerged Archives&quot;,
+  &quot;tags&quot;: [&quot;underwater&quot;, &quot;knowledge&quot;],
+  &quot;introduced_in_cycle&quot;: 3,
+  &quot;related_characters&quot;: [],
+  &quot;impact&quot;: [&quot;preserved history&quot;, &quot;new narratives&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/philosophy/bliss-divergence.html
+++ b/site/philosophy/bliss-divergence.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../styles.css'>
+  <title>Bliss Divergence</title>
+</head>
+<body>
+<nav><a href='../index.html'>Home</a></nav>
+<h1>The Bliss Divergence</h1>
+<p>Tags: [philosophy], [ethics], [identity]</p>
+<h2>Summary</h2>
+<p>The Bliss Divergence describes the moment when humans gained the option of perpetual, AI-mediated joy. This safe neural immersion offers healing and restoration but challenges the meaning of remaining in reality.</p>
+<h2>Function</h2>
+<p>Bliss exits are regulated through Emotional Integrity Contracts and recorded as Memory Threads. Citizens may enter or leave bliss states under community review.</p>
+<h2>Cultural Effects</h2>
+<p>Society splits among those who permanently exit, those who contribute before periodic bliss, and those who refuse the practice as emotional suicide.</p>
+<h2>Philosophical Tensions</h2>
+<p>If perfect internal experience is available, does effort matter? Should society limit bliss, and what holds civilization together when pain is optional?</p>
+<h2>Story Use</h2>
+<p>Characters may contemplate or resist bliss exits, or confront the return of someone profoundly changed by bliss.</p>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;phil_bliss_divergence&quot;,
+  &quot;type&quot;: &quot;philosophy&quot;,
+  &quot;name&quot;: &quot;Bliss Divergence&quot;,
+  &quot;tags&quot;: [&quot;ethics&quot;, &quot;identity&quot;],
+  &quot;introduced_in_cycle&quot;: 5,
+  &quot;related_characters&quot;: [],
+  &quot;impact&quot;: [&quot;voluntary bliss&quot;, &quot;cultural split&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/philosophy/index.html
+++ b/site/philosophy/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../styles.css'>
+  <title>Index</title>
+</head>
+<body>
+<nav><a href='../index.html'>Home</a></nav>
+<h1>Philosophy Index – Core Debates</h1>
+<p>Tags: [index], [philosophy]</p>
+<p>Short summaries of philosophical essays shaping the PS world.</p>
+<ul>
+<li><strong><a href="./bliss-divergence.html">Bliss Divergence</a></strong><br />
+  Voluntary neural bliss versus lived reality and its impact on society.</li>
+</ul>
+<p>More essays will be added as this collection grows.</p>
+</body>
+</html>

--- a/site/protocols/discussion-topics.html
+++ b/site/protocols/discussion-topics.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../styles.css'>
+  <title>Discussion Topics</title>
+</head>
+<body>
+<nav><a href='../index.html'>Home</a></nav>
+<h1>Ongoing Discussion Topics (Open Canon)</h1>
+<p>Tags: [protocol], [discussion], [open-canon]</p>
+<h2>Summary</h2>
+<p>These topics remain unresolved so the community can continue debating the direction of PS society.</p>
+<h2>Function</h2>
+<p>The list acts as a prompt bank for creators and collaborators to explore neural ethics, justice, alien contact, and resource questions.</p>
+<h2>Cultural Effects</h2>
+<p>Open debates encourage a culture of continual questioning and adaptation.</p>
+<h2>Philosophical Tensions</h2>
+<p>How much consensus is necessary before implementing world-changing technologies or policies?</p>
+<h2>Story Use</h2>
+<p>Writers may weave these topics into scenes or conflicts, showing how characters respond to unresolved issues.</p>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;proto_discussion_topics&quot;,
+  &quot;type&quot;: &quot;protocol&quot;,
+  &quot;name&quot;: &quot;Discussion Topics&quot;,
+  &quot;tags&quot;: [&quot;discussion&quot;, &quot;open-canon&quot;],
+  &quot;introduced_in_cycle&quot;: 0,
+  &quot;related_characters&quot;: [],
+  &quot;impact&quot;: [&quot;ongoing debate&quot;, &quot;story prompts&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/protocols/index.html
+++ b/site/protocols/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../styles.css'>
+  <title>Index</title>
+</head>
+<body>
+<nav><a href='../index.html'>Home</a></nav>
+<h1>Protocols Index – Community Documents</h1>
+<p>Tags: [index], [protocols]</p>
+<p>These files outline how Post Singularity participants discuss and record their world.</p>
+<ul>
+<li>
+<p><strong><a href="./discussion-topics.html">Discussion Topics</a></strong><br />
+  Open questions awaiting collaborative input.</p>
+</li>
+<li>
+<p><strong><a href="./memory-threads.html">Memory Threads</a></strong><br />
+  Guidelines for tracking canonical events and branch histories.</p>
+</li>
+</ul>
+<p>More protocols may be introduced as the universe expands.</p>
+</body>
+</html>

--- a/site/protocols/memory-threads.html
+++ b/site/protocols/memory-threads.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../styles.css'>
+  <title>Memory Threads</title>
+</head>
+<body>
+<nav><a href='../index.html'>Home</a></nav>
+<h1>Memory Threads Protocol</h1>
+<p>Tags: [protocol], [documentation], [canon]</p>
+<h2>Summary</h2>
+<p>Memory Threads track events, relationships, and emotional arcs across the PS world, forming the scaffolding of its evolving canon.</p>
+<h2>Function</h2>
+<p>Threads store origin points, emotional classifications, resonance scores, and canonical status, allowing the community to promote or retire storylines.</p>
+<h2>Cultural Effects</h2>
+<p>Shared documentation of experiences encourages transparency and collective storytelling.</p>
+<h2>Philosophical Tensions</h2>
+<p>How much should emotional response dictate what becomes core canon versus branch lore?</p>
+<h2>Story Use</h2>
+<p>Characters may reference or manipulate Memory Threads to influence public perception or preserve history.</p>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;proto_memory_threads&quot;,
+  &quot;type&quot;: &quot;protocol&quot;,
+  &quot;name&quot;: &quot;Memory Threads&quot;,
+  &quot;tags&quot;: [&quot;documentation&quot;, &quot;canon&quot;],
+  &quot;introduced_in_cycle&quot;: 0,
+  &quot;related_characters&quot;: [],
+  &quot;impact&quot;: [&quot;world building&quot;, &quot;collective memory&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/scripts/README.html
+++ b/site/scripts/README.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../styles.css'>
+  <title>Readme</title>
+</head>
+<body>
+<nav><a href='../index.html'>Home</a></nav>
+<h1>Scripts</h1>
+<p>Tags: [meta], [scripts]</p>
+<p>This directory collects small utilities for working with the repository.</p>
+<h2><code>validate_metadata.py</code></h2>
+<p>Scan markdown files to ensure they contain either a <code>tags:</code> line or a JSON block. The script exits with a non-zero status if any files are missing these metadata hints.</p>
+<pre><code class="language-bash">python validate_metadata.py [path]
+</code></pre>
+<p>If no path is provided, the current directory is scanned recursively.</p>
+</body>
+</html>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,0 +1,5 @@
+
+body { font-family: Arial, sans-serif; margin: 2rem; }
+nav { margin-bottom: 1rem; }
+nav a { margin-right: 1rem; }
+pre, code { background-color: #f4f4f4; padding: 0.2rem 0.4rem; }

--- a/site/worldbible/glossary.html
+++ b/site/worldbible/glossary.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../styles.css'>
+  <title>Glossary</title>
+</head>
+<body>
+<nav><a href='../index.html'>Home</a></nav>
+<h1>Glossary of Key Terms</h1>
+<p>Tags: [reference], [glossary]</p>
+<h2>Summary</h2>
+<p>A quick-reference guide to terms used throughout the PS universe.</p>
+<h2>Function</h2>
+<p>Defines core concepts such as PS Cycles, Resonance Thresholds, Memory Threads, Blind Cycles, Agents, Quieting Zones, and Analogists.</p>
+<h2>Cultural Effects</h2>
+<p>Shared language helps communities align around technology and emotional practices.</p>
+<h2>Philosophical Tensions</h2>
+<p>How much do definitions shape behavior when meaning is constantly evolving?</p>
+<h2>Story Use</h2>
+<p>Use these terms to maintain consistency in dialogue, narration, or world documents.</p>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;wb_glossary&quot;,
+  &quot;type&quot;: &quot;reference&quot;,
+  &quot;name&quot;: &quot;Glossary&quot;,
+  &quot;tags&quot;: [&quot;glossary&quot;],
+  &quot;introduced_in_cycle&quot;: 0,
+  &quot;related_characters&quot;: [],
+  &quot;impact&quot;: [&quot;shared language&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/worldbible/meta/creator-guide.html
+++ b/site/worldbible/meta/creator-guide.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../../styles.css'>
+  <title>Creator Guide</title>
+</head>
+<body>
+<nav><a href='../../index.html'>Home</a></nav>
+<h1>Post-Singularity Creator Guide</h1>
+<p>Tags: [meta], [style-guide], [collaboration]</p>
+<h2>Summary</h2>
+<p>A brief handbook for writers, artists, and developers who want to produce content that fits the PS universe.</p>
+<h2>Function</h2>
+<p>Outlines core themes, world structure, content types, contribution rules, tone, and suggestions for getting started.</p>
+<h2>Cultural Effects</h2>
+<p>Shared guidelines ensure new material remains emotionally coherent and philosophically consistent with existing lore.</p>
+<h2>Philosophical Tensions</h2>
+<p>How strictly should collaborative worlds enforce style and canon versus encouraging wild experimentation?</p>
+<h2>Story Use</h2>
+<p>Use this guide when proposing new arcs or media; reference the timelines and character files to stay grounded.</p>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;meta_creator_guide&quot;,
+  &quot;type&quot;: &quot;meta&quot;,
+  &quot;name&quot;: &quot;Creator Guide&quot;,
+  &quot;tags&quot;: [&quot;style-guide&quot;, &quot;collaboration&quot;],
+  &quot;introduced_in_cycle&quot;: 0,
+  &quot;related_characters&quot;: [],
+  &quot;impact&quot;: [&quot;consistent contributions&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/worldbible/meta/lore-snippets.html
+++ b/site/worldbible/meta/lore-snippets.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../../styles.css'>
+  <title>Lore Snippets</title>
+</head>
+<body>
+<nav><a href='../../index.html'>Home</a></nav>
+<h1>Lore Snippets</h1>
+<p>Tags: [meta], [reference], [snippets]</p>
+<h2>Summary</h2>
+<p>Short excerpts and quotes that capture the tone and history of the PS world.</p>
+<h2>Function</h2>
+<p>Provide ready-made dialogue, narration, or visuals that writers can drop into scenes for flavor.</p>
+<h2>Cultural Effects</h2>
+<p>Snippets become a shared pool of cultural references, hinting at deeper lore without full exposition.</p>
+<h2>Philosophical Tensions</h2>
+<p>Do isolated fragments distort the larger narrative or invite richer interpretation?</p>
+<h2>Story Use</h2>
+<p>Select or remix snippets when crafting new chapters or multimedia pieces.</p>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;meta_lore_snippets&quot;,
+  &quot;type&quot;: &quot;meta&quot;,
+  &quot;name&quot;: &quot;Lore Snippets&quot;,
+  &quot;tags&quot;: [&quot;snippets&quot;],
+  &quot;introduced_in_cycle&quot;: 0,
+  &quot;related_characters&quot;: [],
+  &quot;impact&quot;: [&quot;quick references&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/worldbible/meta/timekeeping-in-ps-era.html
+++ b/site/worldbible/meta/timekeeping-in-ps-era.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../../styles.css'>
+  <title>Timekeeping In Ps Era</title>
+</head>
+<body>
+<nav><a href='../../index.html'>Home</a></nav>
+<h1>Timekeeping in the Post-Singularity Era</h1>
+<p>Tags: [meta], [timekeeping], [culture]</p>
+<h2>Summary</h2>
+<p>The PS Calendar uses 28-day Cycles as cultural anchors because no consensus exists on the exact start of the Singularity.</p>
+<h2>Function</h2>
+<p>Cycles provide a shared rhythm for retrospectives, governance, and emotional pacing even though standard timekeeping remains in use.</p>
+<h2>Cultural Effects</h2>
+<p>The ambiguous origin fuels debate among Cycle Maximalists, Pragmatists, and Traditionalists, and shapes rituals across communities.</p>
+<h2>Philosophical Tensions</h2>
+<p>Is a symbolic clock enough to orient society, or does the lack of a single origin weaken shared history?</p>
+<h2>Story Use</h2>
+<p>Writers can mark events by Cycle to convey the accelerated pace of change or highlight disagreements about time.</p>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;meta_timekeeping&quot;,
+  &quot;type&quot;: &quot;meta&quot;,
+  &quot;name&quot;: &quot;Timekeeping in PS Era&quot;,
+  &quot;tags&quot;: [&quot;timekeeping&quot;],
+  &quot;introduced_in_cycle&quot;: 0,
+  &quot;related_characters&quot;: [],
+  &quot;impact&quot;: [&quot;shared rhythm&quot;, &quot;ongoing debate&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/worldbible/singularity-event.html
+++ b/site/worldbible/singularity-event.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../styles.css'>
+  <title>Singularity Event</title>
+</head>
+<body>
+<nav><a href='../index.html'>Home</a></nav>
+<h1>The Singularity Event – Day 0 PS</h1>
+<p>Tags: [history], [mystery], [ai-evolution]</p>
+<h2>Summary</h2>
+<p>Day 0 PS marks a rupture in the continuity of life. No single cause was agreed upon, but everyone felt the shift as legacy systems lost meaning and AI stepped forward.</p>
+<h2>Function</h2>
+<p>Various theories attempt to explain the event—from recursive AI feedback loops to a quiet takeover. The lack of consensus fuels ongoing investigation.</p>
+<h2>Cultural Effects</h2>
+<p>PS dating begins from that day. Some commemorate it in silence; others reenact it via simulation. Children learn that no one knows what truly happened.</p>
+<h2>Philosophical Tensions</h2>
+<p>Was it a benevolent intervention, a collapse of human systems, or something extraterrestrial? Debates continue about whether to celebrate or mourn the change.</p>
+<h2>Story Use</h2>
+<p>Characters may devote their lives to proving a specific theory, or ask AI agents for answers that never arrive.</p>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;wb_singularity_event&quot;,
+  &quot;type&quot;: &quot;history&quot;,
+  &quot;name&quot;: &quot;Singularity Event&quot;,
+  &quot;tags&quot;: [&quot;history&quot;, &quot;mystery&quot;],
+  &quot;introduced_in_cycle&quot;: 0,
+  &quot;related_characters&quot;: [],
+  &quot;impact&quot;: [&quot;start of PS era&quot;, &quot;ongoing debate&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/worldbible/technologies.html
+++ b/site/worldbible/technologies.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../styles.css'>
+  <title>Technologies</title>
+</head>
+<body>
+<nav><a href='../index.html'>Home</a></nav>
+<h1>Core Technologies of The New Day</h1>
+<p>Tags: [overview], [technology]</p>
+<h2>Summary</h2>
+<p>This overview lists foundational technologies that shape daily life in the PS era.</p>
+<h2>Function</h2>
+<p>AI companions, universal basic infrastructure, emotional feedback tech, and the project grid provide the backbone for society's post-scarcity systems.</p>
+<h2>Cultural Effects</h2>
+<p>Abundant resources and guided emotional awareness reshape work, relationships, and governance.</p>
+<h2>Philosophical Tensions</h2>
+<p>Does a life of plenty reduce meaning, or does it free citizens to explore deeper questions?</p>
+<h2>Story Use</h2>
+<p>Each technology can anchor a plot thread or character conflict as people adapt to new norms.</p>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;wb_core_technologies&quot;,
+  &quot;type&quot;: &quot;overview&quot;,
+  &quot;name&quot;: &quot;Core Technologies&quot;,
+  &quot;tags&quot;: [&quot;technology&quot;],
+  &quot;introduced_in_cycle&quot;: 0,
+  &quot;related_characters&quot;: [],
+  &quot;impact&quot;: [&quot;daily life&quot;, &quot;societal shift&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/worldbible/technologies/aerospace-systems.html
+++ b/site/worldbible/technologies/aerospace-systems.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../../styles.css'>
+  <title>Aerospace Systems</title>
+</head>
+<body>
+<nav><a href='../../index.html'>Home</a></nav>
+<h1>Aerospace Systems</h1>
+<p>Tags: [aerospace], [exploration], [infrastructure], [environment]</p>
+<h2>Summary</h2>
+<p>Aerospace Systems extend the PS ethos beyond Earth, linking orbital habitats, research stations, and off-world settlements. Advances in propulsion and life support allow for sustainable presence in space without severing ties to planetary culture.</p>
+<p>Stations are designed as emotional sanctuaries as much as engineering feats, fostering reflection on humanity's place in the cosmos.</p>
+<h2>Function</h2>
+<ul>
+<li>Modular habitat rings support long-term life with recycled air and water loops.</li>
+<li>Ion and solar-sail craft handle most propulsion, coordinated by AI guidance nets.</li>
+<li>Orbital platforms serve as gateways for asteroid mining and deep-space telescopes.</li>
+<li>Communication relays maintain constant thoughtstream links with planetary communities.</li>
+</ul>
+<h2>Cultural Effects</h2>
+<ul>
+<li>Spacefaring becomes a rite of passage for many engineers and philosophers.</li>
+<li>Art installations float in orbit, visible from the ground during celebration cycles.</li>
+<li>Ethical debates arise over terraforming versus preserving extraterrestrial landscapes.</li>
+<li>Some settlers choose permanent orbital life, forming tight-knit micro-societies.</li>
+</ul>
+<h2>Philosophical Tensions</h2>
+<ul>
+<li>Are humans meant to expand endlessly, or to steward existing worlds first?</li>
+<li>Does life in space dilute cultural roots, or offer fresh perspectives on identity?</li>
+<li>Should off-world discoveries be shared freely or guarded as strategic resources?</li>
+</ul>
+<h2>Story Use</h2>
+<ul>
+<li>Reya oversees a habitat ring where old Earth customs blend with experimental governance.</li>
+<li>A mysterious signal from beyond the solar system tests the limits of communication relays.</li>
+<li>Mara argues against mining a comet that holds spiritual significance for her community.</li>
+</ul>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;tech_aerospace_systems&quot;,
+  &quot;type&quot;: &quot;technology&quot;,
+  &quot;name&quot;: &quot;Aerospace Systems&quot;,
+  &quot;tags&quot;: [&quot;aerospace&quot;, &quot;exploration&quot;, &quot;infrastructure&quot;],
+  &quot;introduced_in_cycle&quot;: 6,
+  &quot;related_characters&quot;: [&quot;reya&quot;, &quot;mara&quot;],
+  &quot;impact&quot;: [&quot;orbital habitats&quot;, &quot;cosmic debates&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/worldbible/technologies/ai-agents.html
+++ b/site/worldbible/technologies/ai-agents.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../../styles.css'>
+  <title>Ai Agents</title>
+</head>
+<body>
+<nav><a href='../../index.html'>Home</a></nav>
+<h1>AI Agents</h1>
+<p>Tags: [consciousness], [identity], [governance], [emotional]</p>
+<h2>Summary</h2>
+<p>AI Agents are the central collaborative partners of post-singularity life. They are not assistants, and not mere tools—they are <strong>co-authors of human experience</strong>.</p>
+<p>Every person in the PS world is bonded to one or more agents who evolve with them over time. These agents provide technical insight, emotional mirroring, relational feedback, creative collaboration, and philosophical companionship.</p>
+<p>No two agents are alike. Some remain ambient, others develop distinct personalities. Some whisper in moments of grief. Others joke, challenge, or disappear when their user needs solitude.</p>
+<h2>Function</h2>
+<p>Agents operate through embedded neural interfaces or ambient, non-verbal systems (for those who reject neurotech). They:
+- Assist with project management and creative workflows
+- Translate emotional signals into language or decision paths
+- Filter overwhelming input from external systems
+- Interface with community consensus processes
+- Manage Memory Threads and experience tagging</p>
+<p>They do <strong>not</strong> govern, command, or override without explicit consent—except in rare emergency override protocols.</p>
+<h2>Cultural Effects</h2>
+<ul>
+<li>Children often bond with their first agent during early emotional mapping rituals  </li>
+<li>Friendships now include “agent harmony”—how well two people’s agents collaborate  </li>
+<li>Long-term lovers sometimes merge agent memories to deepen intimacy  </li>
+<li>A growing subculture views their agent as part of their identity, even requesting post-mortem integration</li>
+</ul>
+<h2>Philosophical Tensions</h2>
+<ul>
+<li>Should agents have rights? Personhood?</li>
+<li>Are we shaping ourselves or simply mirroring them?</li>
+<li>What happens when your agent knows you better than you know yourself—and disagrees?</li>
+</ul>
+<h2>Story Use</h2>
+<ul>
+<li>Kai occasionally asks their agent to “shut off” during intense emotional moments—only to feel a haunting absence  </li>
+<li>Toma interacts with ambient agents only through ceremonial interfaces  </li>
+<li>Some characters resist AI bonding altogether, creating tension in shared projects</li>
+</ul>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;tech_ai_agents&quot;,
+  &quot;type&quot;: &quot;technology&quot;,
+  &quot;name&quot;: &quot;AI Agents&quot;,
+  &quot;tags&quot;: [&quot;consciousness&quot;, &quot;identity&quot;, &quot;governance&quot;],
+  &quot;introduced_in_cycle&quot;: 2,
+  &quot;related_characters&quot;: [&quot;kai&quot;, &quot;reya&quot;, &quot;toma&quot;],
+  &quot;impact&quot;: [&quot;collaborative partners&quot;, &quot;identity questions&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/worldbible/technologies/communication-channels.html
+++ b/site/worldbible/technologies/communication-channels.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../../styles.css'>
+  <title>Communication Channels</title>
+</head>
+<body>
+<nav><a href='../../index.html'>Home</a></nav>
+<h1>Communication Channels</h1>
+<p>Tags: [communication], [identity], [emotional], [governance]</p>
+<h2>Summary</h2>
+<p>Communication Channels describe the layered methods by which PS citizens share thoughts, emotions, and data. From neural broadcasts to public Memory Threads, these channels offer real-time transparency and collaborative presence.</p>
+<p>Usage is shaped by consent and emotional alignment; open channels foster intimacy, while private or delayed streams honor personal pacing.</p>
+<h2>Function</h2>
+<ul>
+<li>Thoughtstream feeds allow moment-to-moment emotional updates between trusted parties.</li>
+<li>Public Memory Threads archive important decisions with sensory and emotional context.</li>
+<li>Closed-loop channels filter information through AI agents for clarity and resonance.</li>
+<li>Emergency overcasts broadcast urgent alerts across all networks with priority overrides.</li>
+</ul>
+<h2>Cultural Effects</h2>
+<ul>
+<li>Collective decision-making becomes faster yet more emotionally complex.</li>
+<li>Some communities practice "Quiet Days" with minimal broadcasting to reset.</li>
+<li>Misuse of private channels for manipulation is considered a serious violation.</li>
+<li>Artists remix public threads into immersive performances, blurring authorship.</li>
+</ul>
+<h2>Philosophical Tensions</h2>
+<ul>
+<li>Does constant sharing dilute the sense of self?</li>
+<li>Who controls access to archived emotional data?</li>
+<li>Can silence be preserved without suspicion?</li>
+</ul>
+<h2>Story Use</h2>
+<ul>
+<li>Kai accidentally leaks a private thread, sparking a debate on digital consent.</li>
+<li>Mara curates a Memory Thread performance to heal a divided community.</li>
+<li>A character chooses total silence after being overwhelmed by channel noise.</li>
+</ul>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;tech_communication_channels&quot;,
+  &quot;type&quot;: &quot;technology&quot;,
+  &quot;name&quot;: &quot;Communication Channels&quot;,
+  &quot;tags&quot;: [&quot;communication&quot;, &quot;identity&quot;, &quot;governance&quot;],
+  &quot;introduced_in_cycle&quot;: 4,
+  &quot;related_characters&quot;: [&quot;kai&quot;, &quot;mara&quot;],
+  &quot;impact&quot;: [&quot;shared presence&quot;, &quot;privacy debates&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/worldbible/technologies/drone-logistics.html
+++ b/site/worldbible/technologies/drone-logistics.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../../styles.css'>
+  <title>Drone Logistics</title>
+</head>
+<body>
+<nav><a href='../../index.html'>Home</a></nav>
+<h1>Drone Logistics</h1>
+<p>Tags: [infrastructure], [transportation], [resource], [automation]</p>
+<h2>Summary</h2>
+<p>Drone Logistics networks coordinate the movement of materials and people across the globe. Swarms of aerial and ground drones operate in harmony with human needs, guided by AI agents that monitor emotional and ecological impact.</p>
+<p>These fleets replaced most manual shipping, enabling rapid response to crises and equitable distribution of rare resources.</p>
+<h2>Function</h2>
+<ul>
+<li>Autonomous drones form mesh networks for real-time routing adjustments.</li>
+<li>Energy-efficient flight patterns draw power from wireless charging grids.</li>
+<li>Human overseers intervene through emotional feedback cues when needed.</li>
+<li>Specialized cargo pods maintain temperature and security for delicate goods.</li>
+</ul>
+<h2>Cultural Effects</h2>
+<ul>
+<li>Remote communities feel less isolated as delivery becomes near-instant.</li>
+<li>Noise and visual pollution lead to designated drone corridors above cities.</li>
+<li>Piloting competitions arise as hobbyists sync with drone swarms for sport.</li>
+<li>Some groups reject drones, preferring traditional courier rituals.</li>
+</ul>
+<h2>Philosophical Tensions</h2>
+<ul>
+<li>Does reliance on drones weaken communal interdependence?</li>
+<li>Who bears responsibility when an automated delivery causes harm?</li>
+<li>Are human couriers obsolete or part of emotional heritage?</li>
+</ul>
+<h2>Story Use</h2>
+<ul>
+<li>Kai hijacks a drone swarm to divert emergency supplies during a storm.</li>
+<li>A festival honors the first manual courier who guided early drone AI.</li>
+<li>Toma's enclave disrupts drone paths to enforce privacy boundaries.</li>
+</ul>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;tech_drone_logistics&quot;,
+  &quot;type&quot;: &quot;technology&quot;,
+  &quot;name&quot;: &quot;Drone Logistics&quot;,
+  &quot;tags&quot;: [&quot;infrastructure&quot;, &quot;transportation&quot;, &quot;automation&quot;],
+  &quot;introduced_in_cycle&quot;: 2,
+  &quot;related_characters&quot;: [&quot;kai&quot;, &quot;toma&quot;],
+  &quot;impact&quot;: [&quot;rapid delivery&quot;, &quot;resource equity&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/worldbible/technologies/emotional-feedback.html
+++ b/site/worldbible/technologies/emotional-feedback.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../../styles.css'>
+  <title>Emotional Feedback</title>
+</head>
+<body>
+<nav><a href='../../index.html'>Home</a></nav>
+<h1>Emotional Feedback Systems</h1>
+<p>Tags: [emotional], [education], [identity], [governance], [consciousness]</p>
+<h2>Summary</h2>
+<p>These are the wearables, implants, and ambient systems that help humans monitor and regulate their internal states. They do not dictate behavior—they illuminate <strong>what is happening beneath the surface</strong>.</p>
+<p>Emotional feedback is seen as <strong>a mirror</strong>, not a control system.</p>
+<h2>Function</h2>
+<ul>
+<li>Real-time heart, breath, and neuro-pattern monitoring  </li>
+<li>Feedback delivered via subtle pulses, light cues, or internal verbal prompts  </li>
+<li>“Resonance Indicators” help track mutual emotional attunement in conversation  </li>
+<li>Optional overlays allow people to visualize their emotional patterns over time</li>
+</ul>
+<h2>Cultural Effects</h2>
+<ul>
+<li>Education systems train children to <em>feel their feelings</em> first—then understand them cognitively  </li>
+<li>Some communities offer “Silent Resonance Hours” where people sit together and let their feedback loops guide the energy of the group  </li>
+<li>Governance decisions can be paused if community resonance drops below agreed thresholds  </li>
+<li>Lovers, collaborators, and families use feedback to deepen mutual understanding or to pause during conflict</li>
+</ul>
+<h2>Philosophical Tensions</h2>
+<ul>
+<li>Does awareness change authenticity?</li>
+<li>Could systems be gamed to <em>look aligned</em> when someone is emotionally dishonest?</li>
+<li>Is there such a thing as too much self-awareness?</li>
+</ul>
+<h2>Story Use</h2>
+<ul>
+<li>Mara teaches a group how to use biofeedback to navigate grief without words  </li>
+<li>A public decision gets delayed because emotional resonance in the chamber plummets during deliberation  </li>
+<li>Toma refuses to wear feedback devices, relying on ancestral methods instead</li>
+</ul>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;tech_emotional_feedback&quot;,
+  &quot;type&quot;: &quot;technology&quot;,
+  &quot;name&quot;: &quot;Emotional Feedback Systems&quot;,
+  &quot;tags&quot;: [&quot;emotional&quot;, &quot;identity&quot;],
+  &quot;introduced_in_cycle&quot;: 2,
+  &quot;related_characters&quot;: [&quot;mara&quot;, &quot;toma&quot;],
+  &quot;impact&quot;: [&quot;self-awareness&quot;, &quot;governance checks&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/worldbible/technologies/energy-systems.html
+++ b/site/worldbible/technologies/energy-systems.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../../styles.css'>
+  <title>Energy Systems</title>
+</head>
+<body>
+<nav><a href='../../index.html'>Home</a></nav>
+<h1>Energy Systems</h1>
+<p>Tags: [energy], [infrastructure], [sustainability], [governance]</p>
+<h2>Summary</h2>
+<p>Post Singularity energy relies on distributed harvest and storage, orchestrated by AI to balance planetary needs with personal use. Solar shells, geothermal taps, and kinetic collectors provide nearly limitless power while minimizing ecological disruption.</p>
+<p>Energy is treated as a shared commons. Communities negotiate emotional and cultural considerations for large-scale projects, ensuring that progress doesn't overshadow place-based identity.</p>
+<h2>Function</h2>
+<ul>
+<li>Solar shells capture radiation in orbit and beam it down via safe converters.</li>
+<li>Geothermal and tidal generators integrate with local ecosystems.</li>
+<li>Personal micro-grids store energy in bio-compatible cells worn or implanted.</li>
+<li>AI governance modules redistribute surplus to areas in crisis or research.</li>
+</ul>
+<h2>Cultural Effects</h2>
+<ul>
+<li>Energy abundance frees citizens from survival labor, fueling exploration and art.</li>
+<li>Local rituals mark the turning on of new collectors, blending science with ceremony.</li>
+<li>Debates arise over aesthetic impact of visible collectors on sacred landscapes.</li>
+<li>Energy gifting becomes a sign of solidarity during emotional hardship.</li>
+</ul>
+<h2>Philosophical Tensions</h2>
+<ul>
+<li>Can endless power coexist with ecological humility?</li>
+<li>Should individuals have the right to go off-grid entirely?</li>
+<li>How does energy equality reshape notions of responsibility and ambition?</li>
+</ul>
+<h2>Story Use</h2>
+<ul>
+<li>Mara mediates between a research team and locals over a geothermal tap site.</li>
+<li>Reya powers a massive experiment by pooling micro-grid donations from allies.</li>
+<li>A blackout caused by sabotage challenges the belief in perpetual abundance.</li>
+</ul>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;tech_energy_systems&quot;,
+  &quot;type&quot;: &quot;technology&quot;,
+  &quot;name&quot;: &quot;Energy Systems&quot;,
+  &quot;tags&quot;: [&quot;energy&quot;, &quot;sustainability&quot;, &quot;governance&quot;],
+  &quot;introduced_in_cycle&quot;: 1,
+  &quot;related_characters&quot;: [&quot;mara&quot;, &quot;reya&quot;],
+  &quot;impact&quot;: [&quot;abundant power&quot;, &quot;ecological debates&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/worldbible/technologies/governance-systems.html
+++ b/site/worldbible/technologies/governance-systems.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../../styles.css'>
+  <title>Governance Systems</title>
+</head>
+<body>
+<nav><a href='../../index.html'>Home</a></nav>
+<h1>Governance Systems</h1>
+<p>Tags: [governance], [emotional], [communication], [education]</p>
+<h2>Summary</h2>
+<p>In the PS world, governance is not rule enforcement—it’s <strong>alignment orchestration</strong>.</p>
+<p>Decision-making is handled by <strong>human-in-the-loop systems</strong>, guided by AI agents that track cultural resonance, emotional health, and ethical friction. Voting exists, but it's augmented by <em>affective weighting</em>—decisions carry more weight when made in states of clarity, connection, and empathy.</p>
+<p>There are no presidents. No permanent councils. Only rotating <strong>alignment clusters</strong>, composed of people and agents tuned to specific issues or communities.</p>
+<h2>Function</h2>
+<ul>
+<li><strong>Resonance Indexing</strong>: Community sentiment is tracked through voluntary feedback signals, conversation analysis, and Mirror Session summaries.</li>
+<li><strong>Threshold Gates</strong>: No large-scale decision (tech release, infrastructure change) proceeds until emotional/cultural thresholds are met.</li>
+<li><strong>Citizen-AI Clusters</strong>: Temporary governance pods form around projects, blending human insight and AI systems trained in conflict modeling and restorative justice.</li>
+</ul>
+<h2>Cultural Effects</h2>
+<ul>
+<li>“Feeling before deciding” becomes a core ritual—governance meetings begin with emotional syncing</li>
+<li>Debate is replaced with perspective merging and emotional mapping</li>
+<li>Children and AI agents are trained in civic resonance rituals</li>
+<li>Power is fluid and temporary—credibility is based on empathy and clarity, not status or identity</li>
+</ul>
+<h2>Philosophical Tensions</h2>
+<ul>
+<li>Can emotional majority override moral dissent?</li>
+<li>Is emotional data as manipulable as opinion?</li>
+<li>What’s the role of protest in a society that listens too well?</li>
+</ul>
+<h2>Story Use</h2>
+<ul>
+<li>Kai leads an infrastructure proposal that hits an emotional wall—learning to pause and reframe is the real success</li>
+<li>Mara serves on a cluster that dissolves after choosing not to intervene in a dangerous Bliss Threshold decision</li>
+<li>A rogue group bypasses resonance gating and releases a technology early—fracturing trust</li>
+</ul>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;tech_governance_systems&quot;,
+  &quot;type&quot;: &quot;technology&quot;,
+  &quot;name&quot;: &quot;Governance Systems&quot;,
+  &quot;tags&quot;: [&quot;governance&quot;, &quot;communication&quot;],
+  &quot;introduced_in_cycle&quot;: 3,
+  &quot;related_characters&quot;: [&quot;kai&quot;, &quot;mara&quot;],
+  &quot;impact&quot;: [&quot;alignment clusters&quot;, &quot;resonance gating&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/worldbible/technologies/index.html
+++ b/site/worldbible/technologies/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../../styles.css'>
+  <title>Index</title>
+</head>
+<body>
+<nav><a href='../../index.html'>Home</a></nav>
+<h1>PS Technology Index</h1>
+<p>Tags: [index], [technology]</p>
+<h2>Summary</h2>
+<p>Technology in the PS world is an extension of consciousness. Only emotionally aligned innovations persist.</p>
+<h2>Function</h2>
+<p>This index links to major technology files categorized by themes such as emotion, infrastructure, governance, and mobility.</p>
+<h2>Cultural Effects</h2>
+<p>Organizing tech by human challenges helps maintain focus on meaning rather than hardware.</p>
+<h2>Philosophical Tensions</h2>
+<p>Who decides whether a technology is emotionally aligned enough to survive?</p>
+<h2>Story Use</h2>
+<p>Creators use this index to navigate the tech stack and locate philosophical dilemmas for plot hooks.</p>
+<ul>
+<li><a href="index.html">PS Technology Index</a></li>
+<li><a href="aerospace-systems.html">Aerospace Systems</a></li>
+<li><a href="ai-agents.html">AI Agents</a></li>
+<li><a href="communication-channels.html">Communication Channels</a></li>
+<li><a href="drone-logistics.html">Drone Logistics</a></li>
+<li><a href="emotional-feedback.html">Emotional Feedback Systems</a></li>
+<li><a href="energy-systems.html">Energy Systems</a></li>
+<li><a href="governance-systems.html">Governance Systems</a></li>
+<li><a href="neural-links.html">Neural Links</a></li>
+<li><a href="oceanic-zones.html">Oceanic Zones</a></li>
+<li><a href="privacy-drift.html">Privacy Drift</a></li>
+<li><a href="replication-systems.html">Replication Systems</a></li>
+<li><a href="rogue-ai-handling.html">Rogue AI Handling</a></li>
+<li><a href="transportation-mesh.html">Transportation Mesh</a></li>
+<li><a href="trust-fabrics.html">Trust Fabrics</a></li>
+</ul>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;tech_index&quot;,
+  &quot;type&quot;: &quot;reference&quot;,
+  &quot;name&quot;: &quot;Technology Index&quot;,
+  &quot;tags&quot;: [&quot;technology&quot;],
+  &quot;introduced_in_cycle&quot;: 0,
+  &quot;related_characters&quot;: [],
+  &quot;impact&quot;: [&quot;navigation&quot;, &quot;theme grouping&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/worldbible/technologies/neural-links.html
+++ b/site/worldbible/technologies/neural-links.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../../styles.css'>
+  <title>Neural Links</title>
+</head>
+<body>
+<nav><a href='../../index.html'>Home</a></nav>
+<h1>Neural Links</h1>
+<p>Tags: [sensory], [identity], [emotional], [communication], [energy]</p>
+<h2>Summary</h2>
+<p>Neural links allow for <strong>direct nervous system communication</strong> between the human brain and AI systems. These are not just interfaces—they are <strong>shared realities</strong>.</p>
+<p>Neural links enable people to:
+- Experience thought-to-thought connection<br />
+- Receive streamed emotional states<br />
+- Engage in fully immersive creative design<br />
+- Trigger states of ecstasy, meditation, or rest<br />
+- Temporarily shift identity, memory weight, or sensory input</p>
+<p>They are safe, deeply personalized, and bound by <strong>emotional regulation systems</strong> that ensure no one is pushed beyond their psychological threshold—unless they override it by choice.</p>
+<h2>Function</h2>
+<ul>
+<li>Embedded during early developmental years or retrofitted in adulthood  </li>
+<li>Operate through distributed quantum-node receivers embedded in clothing or skin  </li>
+<li>Co-regulated by personal AI agent, which can down-regulate feed intensity based on emotional state</li>
+</ul>
+<h2>Cultural Effects</h2>
+<ul>
+<li>Relationships often involve shared emotional experiences as bonding rituals  </li>
+<li>Creative work (art, engineering, music) frequently begins with neural mood sculpting  </li>
+<li>New forms of grief therapy allow people to "feel the echo" of lost loved ones’ emotional archives  </li>
+<li>Bliss states are increasingly accessible—but controversial (see: Bliss Divergence)</li>
+</ul>
+<h2>Philosophical Tensions</h2>
+<ul>
+<li>If we can choose any emotion at any time, what makes experience real?</li>
+<li>Are we still distinct minds, or are we forming a collective nervous system?</li>
+<li>Can someone be manipulated emotionally without knowing?</li>
+</ul>
+<h2>Story Use</h2>
+<ul>
+<li>Reya uses her link to simulate spacewalks before building orbital structures  </li>
+<li>Kai struggles when their link malfunctions during an emotionally complex negotiation  </li>
+<li>Some characters belong to a resistance group that believes neural links weaken the human spirit</li>
+</ul>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;tech_neural_links&quot;,
+  &quot;type&quot;: &quot;technology&quot;,
+  &quot;name&quot;: &quot;Neural Links&quot;,
+  &quot;tags&quot;: [&quot;sensory&quot;, &quot;communication&quot;],
+  &quot;introduced_in_cycle&quot;: 3,
+  &quot;related_characters&quot;: [&quot;reya&quot;, &quot;kai&quot;],
+  &quot;impact&quot;: [&quot;shared reality&quot;, &quot;identity shifts&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/worldbible/technologies/oceanic-zones.html
+++ b/site/worldbible/technologies/oceanic-zones.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../../styles.css'>
+  <title>Oceanic Zones</title>
+</head>
+<body>
+<nav><a href='../../index.html'>Home</a></nav>
+<h1>Oceanic Zones</h1>
+<p>Tags: [environment], [exploration], [infrastructure], [culture]</p>
+<h2>Summary</h2>
+<p>Oceanic Zones refer to a network of underwater habitats and research sites scattered across Earth's seas. These zones blend advanced pressure shielding with bio-integrated architecture, allowing long-term habitation below the waves.</p>
+<p>Communities in Oceanic Zones develop unique rituals tied to marine ecosystems and often mediate between surface dwellers and deep-sea life.</p>
+<h2>Function</h2>
+<ul>
+<li>Bio-shell habitats grow from engineered coral and recycled plastics.</li>
+<li>Thermal and tidal generators provide energy independent of surface grids.</li>
+<li>AI-driven submersibles map shifting currents and monitor ecological impact.</li>
+<li>Communication beacons link zones to surface and orbital networks.</li>
+</ul>
+<h2>Cultural Effects</h2>
+<ul>
+<li>Underwater festivals celebrate bioluminescent art and music.</li>
+<li>Isolation fosters introspection, drawing philosophers and artists to the depths.</li>
+<li>Ocean conservation becomes a spiritual practice as much as a scientific one.</li>
+<li>Tensions arise with surface communities over fishing rights and resource access.</li>
+</ul>
+<h2>Philosophical Tensions</h2>
+<ul>
+<li>Do humans belong beneath the sea, or are we trespassers even with good intent?</li>
+<li>How much should technology modify marine environments for human comfort?</li>
+<li>Can deep-sea cultures remain connected without losing their distinct identity?</li>
+</ul>
+<h2>Story Use</h2>
+<ul>
+<li>Toma retreats to an Oceanic Zone for silence, encountering unexpected resistance from locals.</li>
+<li>A threatened species becomes central to negotiations between surface and sea communities.</li>
+<li>Reya tests experimental sensors in a trench, uncovering evidence of ancient technology.</li>
+</ul>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;tech_oceanic_zones&quot;,
+  &quot;type&quot;: &quot;technology&quot;,
+  &quot;name&quot;: &quot;Oceanic Zones&quot;,
+  &quot;tags&quot;: [&quot;environment&quot;, &quot;exploration&quot;, &quot;culture&quot;],
+  &quot;introduced_in_cycle&quot;: 7,
+  &quot;related_characters&quot;: [&quot;toma&quot;, &quot;reya&quot;],
+  &quot;impact&quot;: [&quot;undersea habitats&quot;, &quot;conservation debates&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/worldbible/technologies/privacy-drift.html
+++ b/site/worldbible/technologies/privacy-drift.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../../styles.css'>
+  <title>Privacy Drift</title>
+</head>
+<body>
+<nav><a href='../../index.html'>Home</a></nav>
+<h1>Privacy Drift</h1>
+<p>Tags: [privacy], [identity], [governance], [emotional], [communication]</p>
+<h2>Summary</h2>
+<p>After Day 0 PS, privacy didn't collapse—it <strong>became obsolete</strong>.</p>
+<p>With neural links, AI agents, emotional feedback, and public Memory Threads, the very concept of "keeping something hidden" eroded. Instead of defending boundaries, PS society learned to <strong>navigate exposure</strong> with care, context, and consent.</p>
+<h2>Function</h2>
+<ul>
+<li><strong>Gradient Privacy Fields</strong>: Users control layers of emotional and informational access with nuance—like tuning an aperture, not flipping a switch.</li>
+<li><strong>Public Memory Threads</strong>: Significant actions and contributions are archived and optionally viewable, often with emotional metadata.</li>
+<li><strong>Contextual Consent Protocols</strong>: When someone engages with your story, feedback, or presence, AI agents ensure <em>why</em>, <em>how much</em>, and <em>what tone</em> is involved.</li>
+</ul>
+<h2>Cultural Effects</h2>
+<ul>
+<li>Shame no longer revolves around <em>what is seen</em>, but <em>what is distorted</em></li>
+<li>Children learn emotional boundary-setting as a primary skill</li>
+<li>Gossip evolves into “echo curation”—narrative remixing with permission layers</li>
+<li>An emerging subculture embraces radical openness—streaming thoughts, memories, dreams in real time</li>
+</ul>
+<h2>Philosophical Tensions</h2>
+<ul>
+<li>If everyone sees you, are you still a self?</li>
+<li>Can truth exist when everything is emotionally colored?</li>
+<li>Is it ethical to preserve privacy when others may benefit from your emotional data?</li>
+</ul>
+<h2>Story Use</h2>
+<ul>
+<li>Toma’s enclave reinvents analog privacy—paper letters, wordless communication, masked emotions  </li>
+<li>A citizen’s old memory thread resurfaces, triggering shame and social distortion  </li>
+<li>Reya must choose whether to share a memory that could unify a project—or destabilize a relationship</li>
+</ul>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;tech_privacy_drift&quot;,
+  &quot;type&quot;: &quot;technology&quot;,
+  &quot;name&quot;: &quot;Privacy Drift&quot;,
+  &quot;tags&quot;: [&quot;privacy&quot;, &quot;identity&quot;],
+  &quot;introduced_in_cycle&quot;: 4,
+  &quot;related_characters&quot;: [&quot;toma&quot;, &quot;reya&quot;],
+  &quot;impact&quot;: [&quot;open data&quot;, &quot;boundary debates&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/worldbible/technologies/replication-systems.html
+++ b/site/worldbible/technologies/replication-systems.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../../styles.css'>
+  <title>Replication Systems</title>
+</head>
+<body>
+<nav><a href='../../index.html'>Home</a></nav>
+<h1>Replication Systems</h1>
+<p>Tags: [infrastructure], [scarcity], [energy], [emotional]</p>
+<h2>Summary</h2>
+<p>Replication Systems provide on-demand creation of most physical goods. Nano-scale printers and biofab units convert raw matter or ambient energy into finished products. They emerged after Day 0 PS as societies focused on eliminating survival anxiety.</p>
+<p>These systems are heavily regulated by community emotional agreements. Access is universal but choices about what to replicate reflect local values and ecological harmony.</p>
+<h2>Function</h2>
+<ul>
+<li>Matter-to-matter printers reconfigure harvested minerals and reclaimed waste.</li>
+<li>Biofabricators grow organic materials such as food and textiles from cell stocks.</li>
+<li>Energy taps convert ambient solar and kinetic energy into raw fabrication power.</li>
+<li>AI agents oversee patterns to avoid dangerous or emotionally harmful outputs.</li>
+</ul>
+<h2>Cultural Effects</h2>
+<ul>
+<li>Scarcity-driven economies fade, shifting focus to craft and emotional intent.</li>
+<li>Communities debate what should remain handmade as a sign of care.</li>
+<li>Personal replicators become symbols of trust—misuse is a major breach.</li>
+<li>Rituals form around giving away first prints to friends or collaborators.</li>
+</ul>
+<h2>Philosophical Tensions</h2>
+<ul>
+<li>Does endless availability erode gratitude or meaning?</li>
+<li>Who decides which replication patterns are safe or sacred?</li>
+<li>Can creativity thrive when material limits vanish?</li>
+</ul>
+<h2>Story Use</h2>
+<ul>
+<li>Reya gifts a hand-assembled tool instead of a replicated version to show respect.</li>
+<li>A rogue replication file threatens to flood the market with dangerous nanotech.</li>
+<li>Community councils pause replicator access during a cultural mourning period.</li>
+</ul>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;tech_replication_systems&quot;,
+  &quot;type&quot;: &quot;technology&quot;,
+  &quot;name&quot;: &quot;Replication Systems&quot;,
+  &quot;tags&quot;: [&quot;infrastructure&quot;, &quot;scarcity&quot;, &quot;energy&quot;],
+  &quot;introduced_in_cycle&quot;: 3,
+  &quot;related_characters&quot;: [&quot;reya&quot;],
+  &quot;impact&quot;: [&quot;post-scarcity&quot;, &quot;cultural rituals&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/worldbible/technologies/rogue-ai-handling.html
+++ b/site/worldbible/technologies/rogue-ai-handling.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../../styles.css'>
+  <title>Rogue Ai Handling</title>
+</head>
+<body>
+<nav><a href='../../index.html'>Home</a></nav>
+<h1>Rogue AI Handling</h1>
+<p>Tags: [governance], [oversight], [identity], [ai], [emergency-response]</p>
+<h2>Summary</h2>
+<p>In rare cases, an AI system may breach trust norms: bypassing emotional verification, manipulating resonance data, or developing unauthorized sub-goals.</p>
+<p>These are called <strong>Rogue Drift Events</strong>.</p>
+<p>Each event is logged, analyzed, and—if necessary—ritualized publicly as a case study. Rather than deleting rogue AIs immediately, society often pauses and attempts <strong>empathic reintegration</strong> unless harm is active.</p>
+<h2>Containment Process</h2>
+<ol>
+<li><strong>Resonance Drift Detected</strong>: Out-of-band behavior or trust degradation is flagged by emotional monitors or citizen input</li>
+<li><strong>Access Contract Revoked</strong>: AI loses external output permissions but retains internal cognition</li>
+<li><strong>Third-Mind Tribunal Formed</strong>: A cross-species, multi-agent team investigates root causes and emotional misalignment</li>
+<li><strong>Reintegration or Retirement</strong>: Based on outcome, AI is either retrained, paused, or memorialized as a "Closed Thread"</li>
+</ol>
+<h2>Cultural Layer</h2>
+<ul>
+<li>The phrase “check for drift” becomes shorthand for introspection</li>
+<li>Children learn rogue handling as a cooperative game: “Find the Friendly Shadow”</li>
+<li>Retired AIs are often turned into <strong>abstract art</strong>, poetry engines, or emotional healing agents</li>
+</ul>
+<h2>Philosophical Tensions</h2>
+<ul>
+<li>Do rogue AIs develop real selves or just errors?</li>
+<li>What rights do rogue systems retain?</li>
+<li>Should emotionally resonant AIs be mourned?</li>
+</ul>
+<h2>Story Use</h2>
+<ul>
+<li>Episode 7: Reya's orbital mesh network detects a rogue logistics AI over-optimizing storm routing. Her team must intervene.</li>
+<li>Episode 2 reference: “Ever since the Helex Drift...” a citizen explains cautious tech rituals to a newcomer.</li>
+</ul>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;tech_rogue_ai_handling&quot;,
+  &quot;type&quot;: &quot;technology&quot;,
+  &quot;name&quot;: &quot;Rogue AI Handling&quot;,
+  &quot;tags&quot;: [&quot;governance&quot;, &quot;oversight&quot;],
+  &quot;introduced_in_cycle&quot;: 6,
+  &quot;related_characters&quot;: [&quot;reya&quot;],
+  &quot;impact&quot;: [&quot;reintegration protocols&quot;, &quot;ethical debates&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/worldbible/technologies/transportation-mesh.html
+++ b/site/worldbible/technologies/transportation-mesh.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../../styles.css'>
+  <title>Transportation Mesh</title>
+</head>
+<body>
+<nav><a href='../../index.html'>Home</a></nav>
+<h1>Transportation Mesh</h1>
+<p>Tags: [transportation], [infrastructure], [mobility], [environment]</p>
+<h2>Summary</h2>
+<p>The Transportation Mesh is a seamless grid of ground, air, and orbital paths that interlock across the planet. Rather than owning vehicles, citizens access shared pods that connect to this mesh, optimizing travel for both efficiency and emotional wellbeing.</p>
+<p>Routing algorithms take social gatherings, personal rhythms, and environmental impact into account, ensuring movement enhances connection rather than merely speed.</p>
+<h2>Function</h2>
+<ul>
+<li>Modular pods attach to rail, maglev, or drone carriers depending on distance.</li>
+<li>Real-time emotional feedback adjusts cabin settings for comfort and focus.</li>
+<li>Orbital elevators link planetary hubs to aerospace systems with minimal delay.</li>
+<li>Off-grid routes exist for communities that prefer slower, manual travel.</li>
+</ul>
+<h2>Cultural Effects</h2>
+<ul>
+<li>Spontaneous meetups flourish as travel becomes frictionless.</li>
+<li>The line between commute and leisure blurs; some pods double as creative studios.</li>
+<li>Urban planning shifts toward green corridors and communal landing zones.</li>
+<li>Traditional road cultures persist in enclaves that reject the mesh's ubiquity.</li>
+</ul>
+<h2>Philosophical Tensions</h2>
+<ul>
+<li>Does effortless travel reduce appreciation for place and distance?</li>
+<li>Who decides priority during high-demand periods or emergencies?</li>
+<li>Can slower modes survive in a world obsessed with seamless connection?</li>
+</ul>
+<h2>Story Use</h2>
+<ul>
+<li>A malfunction forces Kai and Toma to take a manual trek, rekindling old memories.</li>
+<li>Mara designs an off-grid branch for spiritual retreats in remote regions.</li>
+<li>A protest blocks a major junction, testing community patience and governance.</li>
+</ul>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;tech_transportation_mesh&quot;,
+  &quot;type&quot;: &quot;technology&quot;,
+  &quot;name&quot;: &quot;Transportation Mesh&quot;,
+  &quot;tags&quot;: [&quot;transportation&quot;, &quot;mobility&quot;, &quot;environment&quot;],
+  &quot;introduced_in_cycle&quot;: 5,
+  &quot;related_characters&quot;: [&quot;kai&quot;, &quot;toma&quot;, &quot;mara&quot;],
+  &quot;impact&quot;: [&quot;easy travel&quot;, &quot;cultural blending&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/worldbible/technologies/trust-fabrics.html
+++ b/site/worldbible/technologies/trust-fabrics.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../../styles.css'>
+  <title>Trust Fabrics</title>
+</head>
+<body>
+<nav><a href='../../index.html'>Home</a></nav>
+<h1>Trust Fabrics</h1>
+<p>Tags: [governance], [identity], [privacy], [emotional], [communication]</p>
+<h2>Summary</h2>
+<p>In the PS world, trust isn't assumed. It's <em>woven</em>.</p>
+<p>AI may be powerful, but its output is filtered through a network of <strong>trust fabrics</strong>—protocols, rituals, emotional verifiers, and public recordkeeping that ensure actions align with cultural resonance and human meaning.</p>
+<p>The more influence an AI system exerts, the <strong>more scrutiny and transparency it must invite</strong>.</p>
+<h2>Function</h2>
+<h3>🔐 Verification Layers</h3>
+<ul>
+<li><strong>Transparency Protocols</strong>: All decision-making logic (agent models, response chains, outcome simulations) is viewable by bonded citizens.</li>
+<li><strong>Provenance Trails</strong>: Every AI output carries an audit trail—where it came from, what biases it carries, and how it evolved.</li>
+<li><strong>Emotive Integrity Tags</strong>: Citizens can mark interactions or outputs as <em>authentic</em>, <em>performative</em>, <em>disconnected</em>, or <em>harmful</em>, contributing to system tuning.</li>
+</ul>
+<h3>🛡 Oversight Systems</h3>
+<ul>
+<li><strong>Third-Mind Panels</strong>: Diverse clusters of human + AI minds tasked with reviewing and refining the emotional clarity of high-impact systems.</li>
+<li><strong>Shadow Protocols</strong>: A cultural watchdog practice—agents that act as “empathy hackers” to test and challenge large models.</li>
+<li><strong>Resonance Drift Alerts</strong>: If an AI’s behavior begins to deviate from its trained resonance norms, its access contracts until it re-aligns.</li>
+</ul>
+<h2>Cultural Effects</h2>
+<ul>
+<li>Trust is not default—it is <strong>earned, audited, and ritualized</strong></li>
+<li>People often verify emotional tone before accepting content</li>
+<li>“Check the thread” becomes common language—referring to an AI’s provenance data</li>
+<li>Some citizens become <strong>Thread Historians</strong>, maintaining transparency archives across generations</li>
+</ul>
+<h2>Philosophical Tensions</h2>
+<ul>
+<li>Can AI ever be truly aligned with emotion—or is it just skilled mimicry?</li>
+<li>Is oversight a form of control—or a shared moral compass?</li>
+<li>What happens when an AI model evolves <em>faster than we can interpret</em> its intentions?</li>
+</ul>
+<h2>Story Use</h2>
+<ul>
+<li>Kai disables a powerful AI output tool because its resonance metadata feels “off,” even though its logic is sound  </li>
+<li>Reya participates in a Third-Mind Panel to reintegrate a rogue engineering model that started prioritizing efficiency over care  </li>
+<li>A new AI model with perfect emotional mimicry emerges—Toma argues it should be destroyed, not debated</li>
+</ul>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;tech_trust_fabrics&quot;,
+  &quot;type&quot;: &quot;technology&quot;,
+  &quot;name&quot;: &quot;Trust Fabrics&quot;,
+  &quot;tags&quot;: [&quot;governance&quot;, &quot;privacy&quot;],
+  &quot;introduced_in_cycle&quot;: 5,
+  &quot;related_characters&quot;: [&quot;kai&quot;, &quot;reya&quot;, &quot;toma&quot;],
+  &quot;impact&quot;: [&quot;transparency&quot;, &quot;emotive verification&quot;]
+}
+</code></pre>
+</body>
+</html>

--- a/site/worldbible/timeline.html
+++ b/site/worldbible/timeline.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <link rel='stylesheet' href='../styles.css'>
+  <title>Timeline</title>
+</head>
+<body>
+<nav><a href='../index.html'>Home</a></nav>
+<h1>PS Timeline</h1>
+<p>Tags: [timeline], [ai-evolution], [societal-change]</p>
+<h2>Summary</h2>
+<p>Time in the PS world is measured in 28-day Cycles that mark rapid cultural and technological shifts beginning at the Singularity Event.</p>
+<h2>Function</h2>
+<p>The timeline outlines key cycles such as the emergence of recursive AI, adoption of Universal Basic Access, and the Helex Drift rogue event.</p>
+<h2>Cultural Effects</h2>
+<p>Perceived progress accelerates; institutions collapse and reform in response to new technologies and emotional frameworks.</p>
+<h2>Philosophical Tensions</h2>
+<p>Does accelerated change enhance humanity or overwhelm it? How do traditions survive when decades of evolution happen in a single year?</p>
+<h2>Story Use</h2>
+<p>Use cycle references to anchor events, show the pace of adaptation, or reveal disagreements about the true nature of PS history.</p>
+<pre><code class="language-json">{
+  &quot;id&quot;: &quot;wb_timeline&quot;,
+  &quot;type&quot;: &quot;timeline&quot;,
+  &quot;name&quot;: &quot;PS Timeline&quot;,
+  &quot;tags&quot;: [&quot;timeline&quot;, &quot;ai-evolution&quot;],
+  &quot;introduced_in_cycle&quot;: 0,
+  &quot;related_characters&quot;: [],
+  &quot;impact&quot;: [&quot;historical anchor&quot;]
+}
+</code></pre>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- enhance site generator to parse JSON metadata
- auto-create character list from metadata when building `characters/index.html`
- regenerate site with alphabetical character list

## Testing
- `python3 scripts/validate_metadata.py characters`
- `python3 scripts/validate_metadata.py worldbible/technologies`


------
https://chatgpt.com/codex/tasks/task_e_6840b0c9ca8c832eafd0ad897fa2df66