### PR TITLE
Add pending review process

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -67,3 +67,8 @@ How this might appear in a character arc, setting detail, or dramatic scene.
   "impact": ["emotional sharing", "experience streaming"]
 }
 ```
+
+## Submitting Experimental Ideas
+- Place controversial or uncertain concepts in the [`pending-review/`](pending-review/) folder.
+- Log the submission in [`submissions-log.md`](submissions-log.md) along with your notes and intended cycle.
+- Once discussed and approved, the material can be moved to the appropriate directory or deleted.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ See the [Contributing guide](Contributing.md) for how to submit ideas. New
 Markdown files should follow the template outlined there. Helpful starting
 points are the [Character Index](characters/index.md) and the
 [Technology Index](worldbible/technologies/index.md).
+Experimental or controversial drafts belong in [`pending-review/`](pending-review/)
+and should be noted in [`submissions-log.md`](submissions-log.md).
 
 ## Technical Tools
 

--- a/pending-review/README.md
+++ b/pending-review/README.md
@@ -1,0 +1,19 @@
+# Pending Review
+Tags: [meta], [submissions]
+
+This folder houses controversial or exploratory ideas that haven't been accepted into the main canon yet.
+Creators should place drafts here when they are uncertain about tone, emotional alignment, or broader impact.
+Files may be revised or removed after review.
+Refer to [../submissions-log.md](../submissions-log.md) to track who submitted which idea and the final decision.
+
+```json
+{
+  "id": "meta_pending_review",
+  "type": "meta",
+  "name": "Pending Review",
+  "tags": ["submissions"],
+  "introduced_in_cycle": 0,
+  "related_characters": [],
+  "impact": ["idea staging"]
+}
+```

--- a/submissions-log.md
+++ b/submissions-log.md
@@ -1,0 +1,22 @@
+# Submissions Log
+Tags: [meta], [review]
+
+This file tracks contributions, particularly those placed in `pending-review/`.
+
+| Cycle | Contributor | File/Idea | Status | Notes |
+|-------|-------------|----------|--------|-------|
+| 0 | repo setup | pending-review folder | accepted | initial structure |
+
+Please append new rows when submitting or revising ideas. Use cycle numbering consistent with other metadata files.
+
+```json
+{
+  "id": "meta_submissions_log",
+  "type": "meta",
+  "name": "Submissions Log",
+  "tags": ["review"],
+  "introduced_in_cycle": 0,
+  "related_characters": [],
+  "impact": ["tracking contributions"]
+}
+```

--- a/worldbible/meta/creator-guide.md
+++ b/worldbible/meta/creator-guide.md
@@ -16,6 +16,10 @@ How strictly should collaborative worlds enforce style and canon versus encourag
 ## Story Use
 Use this guide when proposing new arcs or media; reference the timelines and character files to stay grounded.
 
+### Pending Review Folder
+Drafts that push boundaries or need discussion should go in [`../../pending-review/`](../../pending-review/).
+Record the submission in [`../../submissions-log.md`](../../submissions-log.md) so others know its status.
+
 ```json
 {
   "id": "meta_creator_guide",


### PR DESCRIPTION
## Summary
- add `/pending-review` folder for experimental ideas
- introduce `submissions-log.md` to track contributions
- document the new workflow in README, Contributing guide, and Creator Guide

## Testing
- `python tools/scripts/validate_metadata.py .`

------
https://chatgpt.com/codex/tasks/task_e_68476e622cb4832e97018dcbf0626c7c