### PR TITLE
Introduce voting option for debate branches

### DIFF
--- a/.github/ISSUE_TEMPLATE/debate-branch.md
+++ b/.github/ISSUE_TEMPLATE/debate-branch.md
@@ -1,0 +1,35 @@
+---
+name: Debate Branch
+about: Discuss contested contributions via a dedicated branch
+title: "[Debate]: "
+labels: debate
+assignees: ''
+---
+
+## Overview
+
+## Relevant Files
+
+## Points of Contention
+
+## Proposed Outcomes
+
+## Vote Tally
+(maintainers record reactions and threshold here)
+
+## Resolution
+(maintainers fill in once the debate concludes)
+
+Tags: [meta], [template]
+
+```json
+{
+  "id": "template_debate_branch",
+  "type": "meta",
+  "name": "Debate Branch Issue Template",
+  "tags": ["template"],
+  "introduced_in_cycle": 0,
+  "related_characters": [],
+  "impact": ["structured debate"]
+}
+```

--- a/Contributing.md
+++ b/Contributing.md
@@ -71,4 +71,5 @@ How this might appear in a character arc, setting detail, or dramatic scene.
 ## Submitting Experimental Ideas
 - Place controversial or uncertain concepts in the [`pending-review/`](pending-review/) folder.
 - Log the submission in [`submissions-log.md`](submissions-log.md) along with your notes and intended cycle.
+- For drawn-out discussions, create a debate branch and issue as described in [docs/debate-branches.md](docs/debate-branches.md) to follow the structured debate process and use the optional voting system if consensus stalls.
 - Once discussed and approved, the material can be moved to the appropriate directory or deleted.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ points are the [Character Index](characters/index.md) and the
 [Technology Index](worldbible/technologies/index.md).
 Experimental or controversial drafts belong in [`pending-review/`](pending-review/)
 and should be noted in [`submissions-log.md`](submissions-log.md).
+For lengthy disagreements, follow the [Debate Branches guide](docs/debate-branches.md) for a structured process, including optional voting when consensus is difficult.
 
 ## Technical Tools
 

--- a/docs/debate-branches.md
+++ b/docs/debate-branches.md
@@ -1,0 +1,43 @@
+# Debate Branches Guide
+Tags: [meta], [workflow], [collaboration]
+
+## Summary
+Use a debate branch when a contribution might significantly alter existing lore or cause disagreement. This process keeps discussions organized and transparent.
+
+## Procedure
+1. Create a branch named `debate/your-topic` from `main`.
+2. Open a GitHub issue with the **Debate Branch** template and link the branch.
+3. Describe the problem and proposed changes in the issue, referencing relevant files.
+4. Discuss in the issue thread while committing updates to the branch.
+5. *Optional:* call for a vote by posting a `### Vote` comment that lists the options. Participants respond with `:+1:` or `-1:` reactions (or `+1`/`-1` comments). A proposal passes with a simple majority or a 60% threshold as agreed by the maintainers.
+6. When consensus or a vote resolves the matter, post a `### Resolution` comment summarizing the decision and reference the final commit.
+7. Merge or close the branch and log the outcome in [`../submissions-log.md`](../submissions-log.md).
+
+## Comment Structure
+- **Argument**: State your position succinctly, referencing line numbers or commits.
+- **Counterargument**: Address the prior argument or provide new evidence.
+- Keep each comment focused on a single idea so others can reply clearly.
+
+## Voting
+When discussion stalls or multiple proposals remain, maintainers may call for a vote. Summarize the options in a `### Vote` comment. Participants express support with `:+1:` reactions or `+1` comments. Tally the responses and note the threshold used (simple majority or 60%). Record the outcome in the issue before posting the final resolution.
+
+## Cultural Effects
+Structured debates encourage thoughtful collaboration without stalling other work.
+
+## Philosophical Tensions
+Does formal debate help refine ideas, or can it stifle spontaneity?
+
+## Story Use
+Apply this method when introducing technology, characters, or lore that might conflict with prior contributions.
+
+```json
+{
+  "id": "meta_debate_branches",
+  "type": "meta",
+  "name": "Debate Branches Guide",
+  "tags": ["workflow", "collaboration"],
+  "introduced_in_cycle": 0,
+  "related_characters": [],
+  "impact": ["structured debate"]
+}
+```


### PR DESCRIPTION
## Summary
- add Vote Tally section to debate branch issue template
- expand debate branch guide with steps for optional voting
- note optional voting in README and Contributing

## Testing
- `python tools/scripts/validate_metadata.py`


------
https://chatgpt.com/codex/tasks/task_e_687d2ef7b810832e9085228e82694633