### PR TITLE
Add AI Trust philosophy essay

### DIFF
--- a/philosophy/ai-trust.md
+++ b/philosophy/ai-trust.md
@@ -1,0 +1,33 @@
+# AI Trust
+Tags: [philosophy], [culture], [trust]
+
+## Summary
+In the PS world, humans entrust AI with intimate decisions because verification rituals weave accountability into daily life. Practices like [Trust Fabrics](../worldbible/technologies/trust-fabrics.md) and the companionship of [AI Agents](../worldbible/technologies/ai-agents.md) normalize deep partnership while keeping power transparent.
+
+## Function
+Trust emerges through constant cross-checks. AI Agents publicly log key actions and emotional cues. Communities review these logs in open-thread gatherings, comparing them against established Trust Fabric protocols. Shared oversight keeps algorithms aligned with human meaning and cultural norms.
+
+## Cultural Effects
+- Families teach children how to read trust logs before they can read books.
+- Public “thread circles” replay notable agent decisions to reinforce communal understanding.
+- People see agents less as tools and more as accountable companions, thanks to these rituals.
+
+## Philosophical Tensions
+- Does relentless verification strengthen bonds or reveal lingering doubt?
+- If an agent passes all checks yet still manipulates outcomes, who bears responsibility?
+
+## Story Use
+- A character might consult archived trust logs to prove an agent’s innocence.
+- Disputes could arise over expanding fabric layers when trust falters.
+
+```json
+{
+  "id": "phil_ai_trust",
+  "type": "philosophy",
+  "name": "AI Trust",
+  "tags": ["culture", "trust"],
+  "introduced_in_cycle": 0,
+  "related_characters": [],
+  "impact": ["trust culture", "AI scrutiny"]
+}
+```

--- a/philosophy/index.md
+++ b/philosophy/index.md
@@ -5,6 +5,8 @@ Short summaries of philosophical essays shaping the PS world.
 
 - **[Bliss Divergence](./bliss-divergence.md)**  
   Voluntary neural bliss versus lived reality and its impact on society.
+- **[AI Trust](./ai-trust.md)**
+  Cultural reasons humans place faith in AI partners; see “Trust Fabrics” and “AI Agents.”
 
 More essays will be added as this collection grows.
 


### PR DESCRIPTION
## Summary
- introduce a new philosophy essay `AI Trust`
- link the essay from `philosophy/index.md`

## Testing
- `python tools/scripts/validate_metadata.py`

------
https://chatgpt.com/codex/tasks/task_e_687fcce04ff0832e8840dfc7cc0d2ed7