### PR TITLE
Add cycle 8-10 timeline events

### DIFF
--- a/worldbible/events/analog-revival.md
+++ b/worldbible/events/analog-revival.md
@@ -1,0 +1,33 @@
+# Analog Revival – Cycle 10
+Tags: [history], [philosophy], [culture]
+
+## Summary
+After years of deep integration with neural technology, a movement blossoms to reconnect with physical craft and slow contemplation. Centered around Analog Haven, Toma guides gatherings that blend quiet reflection with minimal AI assistance.
+
+## Function
+- Workshops teach manual arts supported only by offline reference tools.
+- Memory Threads are kept on paper logs before being digitized after retreats.
+- AI Agents operate in silent mode, offering help only when explicitly requested.
+
+## Cultural Effects
+- Seasonal festivals celebrate handcrafted art and storytelling circles.
+- Some participants return to fully digital lives refreshed, while others adopt hybrid rhythms of connection and solitude.
+- Youth camps pair neural-link usage with periods of enforced analog practice.
+
+## Philosophical Tensions
+Is this retreat from constant connectivity a step backward or a necessary counterbalance? Can analog rituals coexist with advanced AI without losing their meaning?
+
+## Story Use
+Toma mentors Kai through a week of silent woodworking, inspiring new collaborations that merge neural insights with tangible creation.
+
+```json
+{
+  "id": "event_analog_revival",
+  "type": "history",
+  "name": "Analog Revival",
+  "tags": ["history", "philosophy"],
+  "introduced_in_cycle": 10,
+  "related_characters": ["toma", "kai"],
+  "impact": ["renewed analog practices", "debates on tech balance"]
+}
+```

--- a/worldbible/events/oceanic-bloom.md
+++ b/worldbible/events/oceanic-bloom.md
@@ -1,0 +1,33 @@
+# Oceanic Bloom – Cycle 8
+Tags: [history], [oceanic], [community]
+
+## Summary
+Underwater habitats mature into interconnected Oceanic Zones, drawing settlers into the deep and linking research posts with surface trade routes. Arin and Reya spearhead drone networks that keep these communities thriving.
+
+## Function
+- Bio-shell structures and pressure shielding allow months-long residence.
+- Drone Logistics and AI Agents coordinate supplies and ecological monitoring.
+- Surface hubs sync data with submersible labs, expanding marine studies.
+
+## Cultural Effects
+- Oceanic rituals spread to coastal cities, influencing music and storytelling.
+- Friction grows with surface fishers over resource rights.
+- Young explorers view life beneath the waves as a rite of passage.
+
+## Philosophical Tensions
+Should humanity permanently settle the ocean depths or respect them as a realm apart? Are we caretakers or intruders when technology lets us reshape entire ecosystems?
+
+## Story Use
+Arin leads an expedition to build a new reef observatory while Kai negotiates surface shipping lanes to protect migrating species.
+
+```json
+{
+  "id": "event_oceanic_bloom",
+  "type": "history",
+  "name": "Oceanic Bloom",
+  "tags": ["history", "oceanic"],
+  "introduced_in_cycle": 8,
+  "related_characters": ["arin", "reya"],
+  "impact": ["undersea colonization", "surface tensions"]
+}
+```

--- a/worldbible/events/third-mind-accord.md
+++ b/worldbible/events/third-mind-accord.md
@@ -1,0 +1,33 @@
+# Third-Mind Accord – Cycle 9
+Tags: [history], [governance], [ai]
+
+## Summary
+A new stage of governance emerges as human councils and AI Agents form "Third-Mind" clusters. These pods weave emotional feedback with predictive modeling, aiming for consensus that neither side could reach alone. Mara and Kai help pilot the first interregional network.
+
+## Function
+- Governance Systems upgrade to allow shared decision logs between agents and citizens.
+- Communication Channels broadcast deliberations in real time, inviting wider participation.
+- Rogue AI Handling protocols remain on standby but see less use as trust grows.
+
+## Cultural Effects
+- Communities celebrate cluster appointments with ritual alignment gatherings.
+- Some factions fear loss of human agency and push for slower adoption.
+- Decision cycles shorten, accelerating infrastructure projects.
+
+## Philosophical Tensions
+Does blending human and machine judgment create deeper wisdom or dilute accountability? Who bears responsibility when a cluster's choice backfires?
+
+## Story Use
+Mara oversees a crisis vote using the new system while Kai mentors skeptical activists learning to navigate Third-Mind debates.
+
+```json
+{
+  "id": "event_third_mind_accord",
+  "type": "history",
+  "name": "Third-Mind Accord",
+  "tags": ["history", "governance", "ai"],
+  "introduced_in_cycle": 9,
+  "related_characters": ["mara", "kai"],
+  "impact": ["shared governance", "ai trust debates"]
+}
+```

--- a/worldbible/timeline.md
+++ b/worldbible/timeline.md
@@ -16,6 +16,11 @@ Does accelerated change enhance humanity or overwhelm it? How do traditions surv
 ## Story Use
 Use cycle references to anchor events, show the pace of adaptation, or reveal disagreements about the true nature of PS history.
 
+### Cycle 8–10 Highlights
+- **Cycle 8 – Oceanic Bloom**: Arin and Reya coordinate new undersea settlements as Oceanic Zones link with surface trade routes.
+- **Cycle 9 – Third-Mind Accord**: Mara and Kai help launch governance clusters where AI Agents share decision power with citizens.
+- **Cycle 10 – Analog Revival**: Toma's gatherings at Analog Haven inspire a return to tactile rituals alongside neural tech.
+
 ```json
 {
   "id": "wb_timeline",


### PR DESCRIPTION
## Summary
- Added three new event files under `worldbible/events`:
  - **Oceanic Bloom** (Cycle 8)
  - **Third-Mind Accord** (Cycle 9)
  - **Analog Revival** (Cycle 10)
- Updated `worldbible/timeline.md` with a bullet list summarizing these events.

## Testing
- Ran `python tools/scripts/validate_metadata.py` on the repository to ensure all Markdown files contain required metadata.

------
https://chatgpt.com/codex/tasks/task_e_68825a298fb4832e8240cfcb508f358f