### PR TITLE
Add appearance and heritage details to core characters

### DIFF
--- a/characters/arin.md
+++ b/characters/arin.md
@@ -23,7 +23,10 @@ Arin assists Reya with experimental sensors and partners with Toma to craft
 materials that respect fragile ecosystems.
 
 ## Personal History
-Raised in floating settlements near the Submerged Archives, Arin blended seafarer lore with archival research from an early age.
+Raised in floating settlements near the Submerged Archives, Arin blended seafarer lore with archival research from an early age. His family traces ancestry to Polynesian voyagers and Andean coastal communities, shaping his reverence for oceanic heritage. Decades of salvage missions have made him a respected mapmaker among remote habitats.
+
+## Appearance
+Arin stands around 1.6 meters with bronze skin, short curly black hair, and dark eyes. Marine tattoos spiral along his arms, and he favors lightweight wetsuits and utility belts.
 
 ## Relationship to AI
 He programs narrow AI for his aquatic drones, trusting them for mapping while reserving ecological decisions for human judgment.
@@ -39,6 +42,8 @@ Arin ferries artifacts between the Submerged Archives and the Orbital Sanctuary,
   "tags": ["exploration", "oceanic"],
   "introduced_in_cycle": 1,
   "related_characters": ["reya", "toma", "kai"],
-  "impact": ["marine exploration", "cross-cultural trade"]
+  "impact": ["marine exploration", "cross-cultural trade"],
+  "heritage": "Polynesian and Andean",
+  "appearance": "bronze skin, short curls, marine tattoos"
 }
 ```

--- a/characters/kai.md
+++ b/characters/kai.md
@@ -17,7 +17,10 @@ They wrestle with surrendering control, relearning how to lead humans, and letti
 Kai mediates between factions, sometimes disabling their agent to face conflict unfiltered.
 
 ## Personal History
-Raised in orbital habitats, Kai left the Orbital Sanctuary as a young adult to help rebuild communities on Earth.
+Raised in orbital habitats, Kai left the Orbital Sanctuary as a young adult to help rebuild communities on Earth. Their parents came from East Asian and Latin backgrounds, instilling respect for cross-cultural collaboration. Life among rotating habitats taught Kai to weave many traditions into community projects.
+
+## Appearance
+Kai has a slender build around 1.7 meters tall, olive skin, and dark eyes. Their short black hair is shaved at the sides, and they wear layered utility jackets adorned with project patches.
 
 ## Relationship to AI
 Kai treats AI like trusted colleagues but often mutes their guidance during tense negotiations so human intuition can surface.
@@ -33,6 +36,8 @@ They organize retreats at Analog Haven and coordinate supply exchanges through t
   "tags": ["leadership", "community"],
   "introduced_in_cycle": 1,
   "related_characters": ["reya", "toma"],
-  "impact": ["ecosystem rebuilding", "emotional leadership"]
+  "impact": ["ecosystem rebuilding", "emotional leadership"],
+  "heritage": "East Asian and Latin",
+  "appearance": "olive skin, short black hair, slender build"
 }
 ```

--- a/characters/mara.md
+++ b/characters/mara.md
@@ -22,7 +22,10 @@ Mara designs retreat spaces along the transportation mesh and mediates disputes
 over energy systems and Bliss Threshold decisions.
 
 ## Personal History
-Born into a nomadic mediator family, Mara traveled across settlements before training at the Submerged Archives to honor ancestral memory.
+Born into a nomadic mediator family, Mara traveled across settlements before training at the Submerged Archives to honor ancestral memory. Her lineage blends South Asian and West African traditions, giving her a rich repertoire of ritual languages and songs.
+
+## Appearance
+Mara has deep brown skin, wavy chestnut hair often braided with memory beads, and calm hazel eyes. She stands around 1.65 meters tall and favors flowing robes adorned with subtle patterns.
 
 ## Relationship to AI
 She consults AI sentiment analyses when gauging conflicts but insists final resolutions emerge from communal rituals.
@@ -38,6 +41,8 @@ Mara convenes peace gatherings at the Orbital Sanctuary and retreats to Analog H
   "tags": ["spiritual", "negotiation"],
   "introduced_in_cycle": 1,
   "related_characters": ["kai", "reya", "toma"],
-  "impact": ["conflict mediation", "cultural preservation"]
+  "impact": ["conflict mediation", "cultural preservation"],
+  "heritage": "South Asian and West African",
+  "appearance": "deep brown skin, chestnut hair, memory beads, flowing robes"
 }
 ```

--- a/characters/reya.md
+++ b/characters/reya.md
@@ -17,7 +17,10 @@ She clashes with Toma over automation and often questions whether humanity is re
 Reya must decide if AI or human pilots should guide her first off-world sanctuary.
 
 ## Personal History
-Growing up near the bustling Holo Bazaar, Reya scavenged old tech before studying forgotten schematics in the Submerged Archives.
+Growing up near the bustling Holo Bazaar, Reya scavenged old tech before studying forgotten schematics in the Submerged Archives. Her family roots lie in the deserts of North Africa, where resourceful communities shaped her respect for resilience. She later joined orbital engineers to blend ancient insight with cutting-edge design.
+
+## Appearance
+Reya is tall with warm brown skin and dark eyes. Her tightly coiled black hair is often braided close to her head, and she wears functional jumpsuits with lightweight exoskeleton harnesses.
 
 ## Relationship to AI
 She engineers with AI partners yet keeps manual overrides to ensure every design honors human ethics over efficiency.
@@ -33,6 +36,8 @@ Reya maintains a laboratory module in the Orbital Sanctuary where she prototypes
   "tags": ["innovation", "exploration"],
   "introduced_in_cycle": 1,
   "related_characters": ["kai", "toma"],
-  "impact": ["orbital habitats", "ethical expansion"]
+  "impact": ["orbital habitats", "ethical expansion"],
+  "heritage": "North African",
+  "appearance": "tall, warm brown skin, braided hair, exoskeleton harness"
 }
 ```

--- a/characters/toma.md
+++ b/characters/toma.md
@@ -17,7 +17,10 @@ He questions whether technology can support life without hollowing it out, resis
 Toma often builds for those who once insulted him, demonstrating service and humility.
 
 ## Personal History
-Descended from craft guilds around Analog Haven, Toma learned woodworking and biodynamic farming from elders who survived the Singularity.
+Descended from craft guilds around Analog Haven, Toma learned woodworking and biodynamic farming from elders who survived the Singularity. His ancestry combines Eastern European and Levantine lineages, shaping a stoic yet hospitable demeanor. Years of manual labor left him with calloused hands and a reputation for patient mentorship.
+
+## Appearance
+Toma stands nearly 1.8 meters tall with a sturdy frame, tan skin, and a short beard. Deep-set hazel eyes and weathered hands reveal decades of craftsmanship. He dresses in hand-stitched garments dyed with natural pigments.
 
 ## Relationship to AI
 He employs low-level AI only for resource tracking, refusing automated shortcuts that could erode the artistry of his work.
@@ -33,6 +36,8 @@ Toma rarely leaves Analog Haven except to trade at the Holo Bazaar and consult t
   "tags": ["craft", "tradition"],
   "introduced_in_cycle": 1,
   "related_characters": ["kai", "reya"],
-  "impact": ["handmade living", "philosophical resistance"]
+  "impact": ["handmade living", "philosophical resistance"],
+  "heritage": "Eastern European and Levantine",
+  "appearance": "sturdy build, tan skin, short beard, hand-stitched clothing"
 }
 ```


### PR DESCRIPTION
## Summary
- enrich character bios with more personal history
- add new "Appearance" sections describing physical traits
- store heritage and appearance in JSON metadata blocks

## Testing
- `python tools/scripts/validate_metadata.py`

------
https://chatgpt.com/codex/tasks/task_e_68826a0f951c832e8600819961a2fcae