### PR TITLE
Document contribution lifecycle workflow

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -72,6 +72,7 @@ How this might appear in a character arc, setting detail, or dramatic scene.
 - Place controversial or uncertain concepts in the [`pending-review/`](pending-review/) folder.
 - Log the submission in [`submissions-log.md`](submissions-log.md) along with your notes and intended cycle.
 - For drawn-out discussions, create a debate branch and issue as described in [docs/debate-branches.md](docs/debate-branches.md) to follow the structured debate process and use the optional voting system if consensus stalls.
+- Review the [Issue Resolution Workflow](docs/issue-resolution.md) for the full lifecycle from submission to merge.
 - Once discussed and approved, the material can be moved to the appropriate directory or deleted.
 
 ## 🔍 Pull Request Checks

--- a/docs/debate-branches.md
+++ b/docs/debate-branches.md
@@ -2,7 +2,7 @@
 Tags: [meta], [workflow], [collaboration]
 
 ## Summary
-Use a debate branch when a contribution might significantly alter existing lore or cause disagreement. This process keeps discussions organized and transparent.
+Use a debate branch when a contribution might significantly alter existing lore or cause disagreement. This process keeps discussions organized and transparent. For the complete lifecycle of a contribution, see [issue-resolution.md](issue-resolution.md).
 
 ## Procedure
 1. Create a branch named `debate/your-topic` from `main`.

--- a/docs/issue-resolution.md
+++ b/docs/issue-resolution.md
@@ -1,0 +1,34 @@
+# Issue Resolution Workflow
+Tags: [meta], [workflow], [contribution]
+
+## Summary
+This guide outlines the full lifecycle of a contribution, from initial submission to final merge.
+
+## Lifecycle
+1. **Initial Submission** – Place new or uncertain ideas in `pending-review/`.
+2. **Logging** – Record each submission in `submissions-log.md` with notes and intended cycle.
+3. **Discussion** – If debate is needed, create a debate branch and linked issue following [debate-branches.md](debate-branches.md).
+4. **Validation** – Run `python tools/scripts/validate_metadata.py` and other checks to ensure metadata and structure.
+5. **Approval** – Maintainers review discussion outcomes and validation results, making revisions as needed.
+6. **Final Merge** – Approved work moves to its destination or is removed if rejected, and the log is updated.
+
+## Cultural Effects
+Clear resolution steps keep the world coherent while welcoming experimentation.
+
+## Philosophical Tensions
+Does structured process fuel creativity or constrain it?
+
+## Story Use
+Apply this workflow when contributing lore, characters, or systems to the Post Singularity universe.
+
+```json
+{
+  "id": "meta_issue_resolution",
+  "type": "meta",
+  "name": "Issue Resolution Workflow",
+  "tags": ["workflow", "contribution"],
+  "introduced_in_cycle": 0,
+  "related_characters": [],
+  "impact": ["consistent contributions"]
+}
+```


### PR DESCRIPTION
## Summary
- Document the full lifecycle of a contribution in `docs/issue-resolution.md`.
- Link the new workflow guide from `Contributing.md` and `docs/debate-branches.md`.

## Testing
- `python tools/scripts/validate_metadata.py`

------
https://chatgpt.com/codex/tasks/task_e_68a9eda91b6c832e85dd6fb8dfb7c740