### PR TITLE
Add robotics technology overview

### DIFF
--- a/worldbible/technologies/index.md
+++ b/worldbible/technologies/index.md
@@ -31,6 +31,7 @@ Below are links to each technology document:
 - [Oceanic Zones](./oceanic-zones.md)
 - [Privacy Drift](./privacy-drift.md)
 - [Replication Systems](./replication-systems.md)
+- [Robotics](./robotics.md)
 - [Rogue AI Handling](./rogue-ai-handling.md)
 - [Transportation Mesh](./transportation-mesh.md)
 - [Trust Fabrics](./trust-fabrics.md)

--- a/worldbible/technologies/robotics.md
+++ b/worldbible/technologies/robotics.md
@@ -1,0 +1,36 @@
+# Robotics
+Tags: [automation], [collaboration], [infrastructure]
+
+## Summary
+Adaptive robots sense emotional and ecological context, reshaping their bodies and roles on the fly. They coordinate in swarms similar to [Drone Logistics](./drone-logistics.md) fleets and submit decisions through [Trust Fabrics](./trust-fabrics.md) so human intention stays central.
+
+## Function
+- Modular joints and soft interfaces let robots reconfigure for new tasks.
+- Swarm meshes share sensor data for obstacle avoidance and resource allocation.
+- Emotional telemetry flags misalignment and defers to human collaborators or local AIs.
+
+## Cultural Effects
+- Neighborhoods treat local robot collectives as communal tools rather than property.
+- Craft guilds emerge to design custom skins and behaviors.
+- Some communities restrict swarm presence during ceremonies to preserve intimacy.
+
+## Philosophical Tensions
+- Do adaptive robots erode the line between artifact and citizen?
+- Who is accountable when a swarm consensus harms someone?
+
+## Story Use
+- [Arin](../../characters/arin.md) trains a crew of adaptive builders to repair storm damage while debating their autonomy.
+- A rogue swarm breaks formation, forcing neighbors to rely on [Trust Fabrics](./trust-fabrics.md) for mediation.
+- Robots partner with drone fleets to open pop-up corridors for emergency [Drone Logistics](./drone-logistics.md).
+
+```json
+{
+  "id": "tech_robotics",
+  "type": "technology",
+  "name": "Robotics",
+  "tags": ["automation", "collaboration"],
+  "introduced_in_cycle": 3,
+  "related_characters": ["arin"],
+  "impact": ["adaptive labor", "human-robot symbiosis"]
+}
+```


### PR DESCRIPTION
## Summary
- add robotics technology entry covering adaptive robots, swarms, and human collaboration
- cross-link to drone logistics, trust fabrics, and Arin
- update technology index

## Testing
- `python tools/scripts/validate_metadata.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9ee723c30832ebd6b9308fe663a71