### PR TITLE
Add Mara's Vigil story for core character

### DIFF
--- a/stories/index.md
+++ b/stories/index.md
@@ -6,6 +6,9 @@ Deeper explorations of the PS world, each focusing on a single moment.
 - **[Arin's Dive at the Submerged Archives](./arins-dive-at-the-submerged-archives.md)**
   Arin searches drowned vaults for memories and lost tech.
 
+- **[Mara's Vigil at the Orbital Sanctuary](./maras-vigil-at-the-orbital-sanctuary.md)**
+  Mara mediates between gardeners and adaptive robots above Earth.
+
 ```json
 {
   "id": "story_index",
@@ -13,7 +16,7 @@ Deeper explorations of the PS world, each focusing on a single moment.
   "name": "Stories Index",
   "tags": ["stories"],
   "introduced_in_cycle": 0,
-  "related_characters": ["arin"],
+  "related_characters": ["arin", "mara"],
   "impact": ["narrative anchor"]
 }
 ```

--- a/stories/maras-vigil-at-the-orbital-sanctuary.md
+++ b/stories/maras-vigil-at-the-orbital-sanctuary.md
@@ -1,0 +1,28 @@
+# Mara's Vigil at the Orbital Sanctuary
+Tags: [story], [mediation], [orbital]
+
+[**Mara**](../characters/mara.md) floated through the prayer ring of the [Orbital Sanctuary](../locations/orbital-sanctuary.md) as dawnlight spilled across the curve of Earth. Today she was summoned to settle a quarrel between human gardeners and the adaptive drones tending the hydroponic arrays. The robots had reconfigured the nutrient lattice overnight, optimizing yields but uprooting hand‑woven memorial vines.
+
+Mara anchored herself to a handrail and activated her [Emotional Feedback](../worldbible/technologies/emotional-feedback.md) loop. Heartbeat pulses echoed through the chamber, mirrored by soft glows along the drones’ casings. Each machine’s hue mapped to the tension they sensed in her presence.
+
+She opened a channel to the Sanctuary's Trust Loom—a local instance of [Trust Fabrics](../worldbible/technologies/trust-fabrics.md)—and invited the garden crew into a shared feed. The drones streamed their decision logs; the gardeners streamed memories of planting ceremonies. In the center of the ring, translucent threads stitched these histories together.
+
+Mara hummed an ancestral chant that tempered sharp emotions, allowing the drones’ heuristics to soften. With each note the machines reshaped their limb arrays, curling like ferns instead of angular struts. A message from [Kai](../characters/kai.md) glided through the Accord uplink, reminding them of obligations under the [Third-Mind Accord](../worldbible/events/third-mind-accord.md): efficiency must honor collective meaning.
+
+The gardeners watched as the swarm rearranged the lattice, restoring space for the memorial vines while routing new channels for water. [Adaptive Robotics](../worldbible/technologies/robotics.md) let the machines pivot from rigid efficiency toward ceremonial design.
+
+When the last vine was replanted, Mara recorded the compromise into the Trust Loom. The decision threads pulsed emerald, signaling consensus. A gratitude packet from [Arin](../characters/arin.md) arrived minutes later—he would deliver fresh sea minerals on his next orbit to nourish the revived garden.
+
+Drifting once more along the prayer ring, Mara felt the Sanctuary’s atmosphere settle. The drones resumed their duties with calmer hues, and the gardeners resumed song. For a brief orbit, the line between algorithm and ritual blurred into quiet harmony.
+
+```json
+{
+  "id": "story_maras_vigil",
+  "type": "story",
+  "name": "Mara's Vigil at the Orbital Sanctuary",
+  "tags": ["mediation", "orbital"],
+  "introduced_in_cycle": 12,
+  "related_characters": ["mara", "kai", "arin"],
+  "impact": ["third-mind trust", "robotic harmony"]
+}
+```


### PR DESCRIPTION
## Summary
- add a new narrative featuring Mara mediating between gardeners and adaptive robots in orbit
- list Mara's Vigil in the stories index alongside existing tales

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9ecdefdf4832ea3ff125a550a7eed