### PR TITLE
Fix CrewAI source URL serialization

### DIFF
--- a/tests/test_research_crew.py
+++ b/tests/test_research_crew.py
@@ -1,8 +1,12 @@
+import json
 from pathlib import Path
+
+import pytest
 
 from tools import research_crew as crew_module
 from tools.research_agent import (
     ResearchBrief,
+    Source,
     load_assumptions,
     load_canon_files,
     nearby_canon,
@@ -20,6 +24,31 @@ def test_intermediate_schemas_are_strict() -> None:
     assert crew_module.AuditedEvidence.model_config["extra"] == "forbid"
     assert crew_module.AnalysisPacket.model_config["extra"] == "forbid"
 
+
+def test_source_urls_remain_validated_json_strings() -> None:
+    source = Source(
+        id="S1",
+        title="Primary source",
+        url="https://example.com/research",
+        publisher="Example",
+        published_at="2026-07-26",
+        source_type="primary-research",
+        why_relevant="Regression coverage for CrewAI task persistence.",
+    )
+
+    assert source.url == "https://example.com/research"
+    assert json.loads(json.dumps(source.model_dump()))["url"] == source.url
+
+    with pytest.raises(ValueError):
+        Source(
+            id="S2",
+            title="Invalid source",
+            url="not-a-url",
+            publisher="Example",
+            published_at="unknown",
+            source_type="mock",
+            why_relevant="This must fail validation.",
+        )
 
 def test_mock_crew_cli_uses_existing_pipeline(capsys) -> None:
     result = crew_module.main(

--- a/tools/research_agent.py
+++ b/tools/research_agent.py
@@ -18,7 +18,7 @@ from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Iterable, Literal, Sequence
 
-from pydantic import BaseModel, ConfigDict, Field, HttpUrl
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_validator
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -149,7 +149,10 @@ class StrictModel(BaseModel):
 class Source(StrictModel):
     id: str = Field(description="Short stable identifier such as S1")
     title: str
-    url: HttpUrl
+    url: str = Field(
+        pattern=r"^https?://",
+        description="Absolute HTTP or HTTPS source URL",
+    )
     publisher: str
     published_at: str = Field(description="ISO date when known, otherwise 'unknown'")
     source_type: Literal[
@@ -161,6 +164,12 @@ class Source(StrictModel):
         "mock",
     ]
     why_relevant: str
+
+    @field_validator("url")
+    @classmethod
+    def normalize_url(cls, value: str) -> str:
+        """Keep validated URLs JSON-native for CrewAI task persistence."""
+        return str(HttpUrl(value))
 
 
 class Development(StrictModel):


### PR DESCRIPTION
﻿## What changed

- Keeps source URLs strictly validated as HTTP/HTTPS URLs.
- Normalizes validated URLs to native strings before CrewAI persists typed task outputs.
- Adds regression coverage for valid URL normalization, JSON serialization, and invalid URL rejection.

## Root cause

CrewAI 1.15.7 calls `model_dump()` and then uses its own JSON encoder for task-output persistence. Pydantic `HttpUrl` values remained custom objects in that Python-mode dump, causing the first successful research task to fail with `TypeError: Object of type HttpUrl is not JSON serializable`.

## Impact

The research crew can now persist source-bearing task outputs and continue through its remaining sequential tasks. URL validation and the human-review boundary remain intact.

## Validation

- 14 tests passed against CrewAI 1.15.7
- Exact CrewAI `CrewJSONEncoder` reproduction passed
- Python compilation passed
- Metadata validation passed
- Cohesion score remains 99.24% with one pre-existing cycle-reference warning

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/techninja828/postsingularity/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->