### PR TITLE
Exclude generated directories from metadata scans

### DIFF
--- a/tests/test_metadata_scripts.py
+++ b/tests/test_metadata_scripts.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from tools.scripts import check_cohesion, validate_metadata
+
+
+def test_markdown_collectors_skip_generated_and_vcs_directories(
+    tmp_path: Path,
+) -> None:
+    visible = tmp_path / "content.md"
+    visible.write_text("# Content\n", encoding="utf-8")
+
+    excluded_paths = [
+        tmp_path / ".git" / "logs" / "remote.md",
+        tmp_path / ".venv" / "package.md",
+        tmp_path / "node_modules" / "dependency.md",
+    ]
+    for path in excluded_paths:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("not repository content", encoding="utf-8")
+
+    expected = {str(visible)}
+    assert set(validate_metadata.collect_markdown_files(str(tmp_path))) == expected
+    assert set(check_cohesion.collect_markdown_files(str(tmp_path))) == expected

--- a/tools/scripts/check_cohesion.py
+++ b/tools/scripts/check_cohesion.py
@@ -25,11 +25,13 @@ from typing import List, Dict
 
 JSON_BLOCK = re.compile(r"```json\s*(\{.*?\})\s*```", re.DOTALL | re.IGNORECASE)
 CYCLE_REGEX = re.compile(r"cycle\s*(\d+)", re.IGNORECASE)
+EXCLUDED_DIRS = {".git", ".venv", ".pytest_cache", "__pycache__", "node_modules"}
 
 
 def collect_markdown_files(root: str) -> List[str]:
     files = []
-    for dirpath, _, filenames in os.walk(root):
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [name for name in dirnames if name not in EXCLUDED_DIRS]
         for name in filenames:
             if name.lower().endswith(".md"):
                 files.append(os.path.join(dirpath, name))

--- a/tools/scripts/validate_metadata.py
+++ b/tools/scripts/validate_metadata.py
@@ -24,6 +24,7 @@ from typing import List
 
 TAG_REGEX = re.compile(r'^tags\s*:', re.IGNORECASE | re.MULTILINE)
 JSON_BLOCK_REGEX = re.compile(r'```json', re.IGNORECASE)
+EXCLUDED_DIRS = {'.git', '.venv', '.pytest_cache', '__pycache__', 'node_modules'}
 
 
 def has_required_metadata(text: str) -> bool:
@@ -43,7 +44,8 @@ def check_file(path: str) -> bool:
 
 def collect_markdown_files(root: str) -> List[str]:
     result = []
-    for dirpath, _, filenames in os.walk(root):
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [name for name in dirnames if name not in EXCLUDED_DIRS]
         for filename in filenames:
             if filename.lower().endswith('.md'):
                 result.append(os.path.join(dirpath, filename))


### PR DESCRIPTION
﻿## What changed

- Excludes `.git`, virtual environments, caches, and `node_modules` from both recursive Markdown collectors.
- Adds regression coverage proving repository Markdown is included while VCS/generated Markdown is ignored.

## Root cause

The daily research crew completed successfully and wrote its report, but `validate_metadata.py` recursively traversed `.git`. Because the full checkout contained a remote branch log whose branch name ended in `.md`, the validator treated `.git/logs/...md` as storyworld content and rejected it for missing metadata.

## Impact

Post-generation validation now examines repository content only. The same exclusion is applied to cohesion checks so local environments and dependency trees cannot distort results.

## Validation

- 15 tests passed
- Python compilation passed
- Real repository metadata validation passed
- Cohesion score remains 99.24% with one pre-existing cycle-reference warning
