### PR TITLE
Add repository-aware canon implementation planning

### DIFF
--- a/pending-review/agent-research/README.md
+++ b/pending-review/agent-research/README.md
@@ -21,6 +21,8 @@ review.
   deployment, measured result, or prediction.
 - Reject unsupported certainty, invented URLs, and conclusions that outrun the
   evidence.
+- Verify that each implementation item points to a real file and exact existing
+  heading, and that its proposed edit is consistent with related canon.
 - Update [`research/assumptions.json`](../../research/assumptions.json) only
   after review.
 - Move accepted storyworld changes through the normal contribution workflow.

--- a/research/CREW.md
+++ b/research/CREW.md
@@ -8,7 +8,7 @@ and technology developments, tests them against the assumptions registry, and
 creates non-canonical briefs for human review.
 
 GitHub Actions starts one run each day. The crew is not a persistent background
-process: it starts, completes five bounded tasks, writes a review artifact, opens
+process: it starts, completes six bounded tasks, writes a review artifact, opens
 a pull request, and exits.
 
 ## Crew Roles
@@ -19,11 +19,15 @@ a pull request, and exits.
 3. **Evidence Auditor** deduplicates sources, reconciles conflicts, and removes
    unsupported claims.
 4. **Assumption Analyst** assesses every selected assumption and maps the
-   implications to nearby canon.
-5. **Canon Review Editor** assembles a structured brief without changing canon.
+   real-world and storyworld implications.
+5. **Repository Implementation Mapper** guarantees declared assumption files are
+   considered, then identifies exact files, existing heading anchors, evidence,
+   proposed edits, implementation steps, priorities, and canon conflicts.
+6. **Canon Review Editor** assembles a structured brief without changing canon.
 
 The process is sequential and uses typed task outputs. Deterministic Python
-validation runs after the crew and before any file is written.
+validation rejects unknown repository paths, invented headings, unselected
+assumptions, and unknown source IDs before any file is written.
 
 ## Running Locally
 
@@ -43,7 +47,8 @@ selection and formatting without CrewAI calls or API spend.
 Crew outputs always go to
 [`pending-review/agent-research/`](../pending-review/agent-research/). The crew
 may recommend strengthening, weakening, contradicting, debating, or monitoring
-an assumption, but it does not update the registry or canon.
+an assumption. Its implementation plan is a proposal for human review; it does
+not update the registry or canon.
 
 ```json
 {

--- a/research/README.md
+++ b/research/README.md
@@ -15,7 +15,7 @@ change, but only a human reviewer updates the registry or canon.
 ## Workflow
 
 1. Select an assumption, research lane, or open topic.
-2. Run the five-role daily crew with `postsingularity-crew`, or use
+2. Run the six-role daily crew with `postsingularity-crew`, or use
    `postsingularity-research` for a focused single-agent pass.
 3. Review the generated brief in
    [`pending-review/agent-research/`](../pending-review/agent-research/).

--- a/tests/test_research_agent.py
+++ b/tests/test_research_agent.py
@@ -42,13 +42,43 @@ def test_nearby_canon_explains_why_files_match() -> None:
     assert matches
     assert any(match.path.endswith("ai-agents.md") for match in matches)
     assert all(match.reason for match in matches)
+    assert all(match.headings for match in matches)
+
+
+def test_canon_context_guarantees_declared_assumption_sources() -> None:
+    assumptions = agent.load_assumptions()
+    selected = agent.select_assumptions(
+        "automation, future of work, meaning, and social adaptation",
+        "social-systems",
+        assumptions,
+    )
+    matches = agent.select_canon_context(
+        "automation, future of work, meaning, and social adaptation",
+        "social-systems",
+        agent.load_canon_files(),
+        selected,
+    )
+
+    declared_paths = {
+        path for assumption in selected for path in assumption["canon_sources"]
+    }
+    matched_paths = {match.path for match in matches}
+    assert declared_paths <= matched_paths
+    assert all(match.headings for match in matches)
+    assert all(match.excerpt for match in matches)
+    assert any(match.assumption_ids for match in matches)
 
 
 def test_mock_brief_formats_as_metadata_valid_markdown() -> None:
     assumptions = agent.load_assumptions()
     topic = "AI agent memory and consent"
     selected = agent.select_assumptions(topic, "ai", assumptions)
-    matches = agent.nearby_canon(topic, "ai", agent.load_canon_files())
+    matches = agent.select_canon_context(
+        topic,
+        "ai",
+        agent.load_canon_files(),
+        selected,
+    )
     brief = agent.build_mock_brief(
         topic,
         "ai",
@@ -68,8 +98,19 @@ def test_mock_brief_formats_as_metadata_valid_markdown() -> None:
     )
     assert "MOCK - synthetic test data" in markdown
     assert "PS-AI-002" in markdown
+    assert "## Canon Implementation Plan" in markdown
+    assert "Proposed change:" in markdown
+    assert "Implementation steps:" in markdown
     assert agent.parse_tags(markdown)
     assert "```json" in markdown
+
+    brief.canon_implications[0].target_heading = "Invented heading"
+    try:
+        agent.validate_brief(brief, selected, matches)
+    except ValueError as exc:
+        assert "Unknown target heading" in str(exc)
+    else:
+        raise AssertionError("Invented repository headings must be rejected")
 
 
 def test_write_memo_avoids_overwrite(tmp_path: Path) -> None:

--- a/tests/test_research_crew.py
+++ b/tests/test_research_crew.py
@@ -9,8 +9,8 @@ from tools.research_agent import (
     Source,
     load_assumptions,
     load_canon_files,
-    nearby_canon,
     select_assumptions,
+    select_canon_context,
 )
 
 
@@ -23,6 +23,7 @@ def test_intermediate_schemas_are_strict() -> None:
     assert crew_module.EvidencePacket.model_config["extra"] == "forbid"
     assert crew_module.AuditedEvidence.model_config["extra"] == "forbid"
     assert crew_module.AnalysisPacket.model_config["extra"] == "forbid"
+    assert crew_module.ImplementationPacket.model_config["extra"] == "forbid"
 
 
 def test_source_urls_remain_validated_json_strings() -> None:
@@ -50,6 +51,7 @@ def test_source_urls_remain_validated_json_strings() -> None:
             why_relevant="This must fail validation.",
         )
 
+
 def test_mock_crew_cli_uses_existing_pipeline(capsys) -> None:
     result = crew_module.main(
         [
@@ -67,13 +69,18 @@ def test_mock_crew_cli_uses_existing_pipeline(capsys) -> None:
     assert "Non-canonical research draft" in output
 
 
-def test_build_research_crew_has_five_bounded_roles(monkeypatch) -> None:
+def test_build_research_crew_has_six_bounded_roles(monkeypatch) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "test-only-not-a-real-key")
     monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
     topic = "AI agents and persistent memory"
     assumptions = load_assumptions()
     selected = select_assumptions(topic, "ai", assumptions)
-    matches = nearby_canon(topic, "ai", load_canon_files())
+    matches = select_canon_context(
+        topic,
+        "ai",
+        load_canon_files(),
+        selected,
+    )
 
     crew, final_task = crew_module.build_research_crew(
         topic,
@@ -84,8 +91,9 @@ def test_build_research_crew_has_five_bounded_roles(monkeypatch) -> None:
         verbose=False,
     )
 
-    assert len(crew.agents) == 5
-    assert len(crew.tasks) == 5
+    assert len(crew.agents) == 6
+    assert len(crew.tasks) == 6
+    assert crew.tasks[-2].output_pydantic is crew_module.ImplementationPacket
     assert final_task.output_pydantic is ResearchBrief
     assert all(agent.allow_delegation is False for agent in crew.agents)
 

--- a/tools/research_agent.py
+++ b/tools/research_agent.py
@@ -140,6 +140,8 @@ class CanonMatch:
     reason: str
     score: int
     excerpt: str
+    headings: tuple[str, ...] = ()
+    assumption_ids: tuple[str, ...] = ()
 
 
 class StrictModel(BaseModel):
@@ -192,8 +194,27 @@ class AssumptionAssessment(StrictModel):
 
 class CanonImplication(StrictModel):
     path: str
-    implication: str
+    target_heading: str = Field(
+        description="Exact existing Markdown heading used as the edit anchor"
+    )
+    assumption_ids: list[str] = Field(min_length=1)
+    source_ids: list[str] = Field(min_length=1)
+    relationship: Literal[
+        "supports",
+        "challenges",
+        "qualifies",
+        "extends",
+        "no-material-effect",
+    ]
     recommendation: Literal["monitor", "revise", "debate", "no-change"]
+    priority: Literal["high", "medium", "low", "watch"]
+    rationale: str = Field(min_length=20)
+    proposed_change: str = Field(
+        min_length=30,
+        description="Concrete content change or explicit reason to leave the file unchanged"
+    )
+    implementation_steps: list[str] = Field(min_length=1)
+    dependencies_or_conflicts: list[str]
 
 
 class ResearchBrief(StrictModel):
@@ -228,6 +249,14 @@ def extract_title(text: str, fallback: str) -> str:
     return match.group(1).strip() if match else fallback
 
 
+def extract_headings(text: str) -> tuple[str, ...]:
+    """Return Markdown headings without their leading hash marks."""
+    return tuple(
+        match.group(1).strip()
+        for match in re.finditer(r"^#{1,6}\s+(.+?)\s*$", text, re.MULTILINE)
+    )
+
+
 def tokenize(value: str) -> set[str]:
     return {
         token
@@ -236,9 +265,54 @@ def tokenize(value: str) -> set[str]:
     }
 
 
+def relevant_excerpt(
+    content: str,
+    query_tokens: set[str],
+    max_chars: int = 2200,
+) -> str:
+    """Select the most query-relevant Markdown sections for repository mapping."""
+    sections = [
+        section.strip()
+        for section in re.split(r"(?=^#{1,6}\s+)", content, flags=re.MULTILINE)
+        if section.strip()
+    ]
+    ranked: list[tuple[int, int, str]] = []
+    for index, section in enumerate(sections):
+        section_tokens = tokenize(section)
+        heading_match = re.match(r"^#{1,6}\s+(.+)$", section, re.MULTILINE)
+        heading_tokens = tokenize(heading_match.group(1)) if heading_match else set()
+        score = len(query_tokens & heading_tokens) * 5 + len(
+            query_tokens & section_tokens
+        )
+        ranked.append((score, -index, re.sub(r"\s+", " ", section).strip()))
+
+    ranked.sort(reverse=True)
+    selected: list[str] = []
+    total = 0
+    for _, _, section in ranked:
+        if selected and total + len(section) > max_chars:
+            continue
+        selected.append(section)
+        total += len(section)
+        if total >= max_chars or len(selected) >= 4:
+            break
+    return "\n\n".join(selected)[:max_chars]
+
+
 def load_canon_files(repo_root: Path = REPO_ROOT) -> list[CanonDocument]:
     """Load human-authored canon and narrative Markdown files."""
     documents: list[CanonDocument] = []
+    overview = repo_root / "README.md"
+    if overview.is_file():
+        text = overview.read_text(encoding="utf-8")
+        documents.append(
+            CanonDocument(
+                path="README.md",
+                title=extract_title(text, "PostSingularity"),
+                tags=parse_tags(text),
+                content=text,
+            )
+        )
     for root_name in CANON_ROOTS:
         root = repo_root / root_name
         if not root.exists():
@@ -290,7 +364,7 @@ def nearby_canon(
             reasons.append(f"content: {', '.join(content_hits[:4])}")
         if preferred:
             reasons.append(f"{lane} directory preference")
-        excerpt = re.sub(r"\s+", " ", document.content).strip()[:900]
+        excerpt = relevant_excerpt(document.content, query_tokens)
         ranked.append(
             CanonMatch(
                 path=document.path,
@@ -298,11 +372,78 @@ def nearby_canon(
                 reason="; ".join(reasons),
                 score=score,
                 excerpt=excerpt,
+                headings=extract_headings(document.content),
             )
         )
 
     ranked.sort(key=lambda item: (-item.score, item.path))
     return ranked[:limit]
+
+
+def select_canon_context(
+    topic: str,
+    lane: str,
+    documents: Sequence[CanonDocument],
+    assumptions: Sequence[dict[str, Any]],
+    limit: int = 12,
+) -> list[CanonMatch]:
+    """Combine declared assumption canon with discovered related repository files."""
+    documents_by_path = {document.path: document for document in documents}
+    assumption_ids_by_path: dict[str, list[str]] = {}
+    for assumption in assumptions:
+        for path in assumption["canon_sources"]:
+            assumption_ids_by_path.setdefault(path, []).append(assumption["id"])
+
+    declared: list[CanonMatch] = []
+    for path, assumption_ids in assumption_ids_by_path.items():
+        document = documents_by_path.get(path)
+        if document is None:
+            raise ValueError(f"Declared canon source was not loaded: {path}")
+        related_assumptions = [
+            assumption for assumption in assumptions if assumption["id"] in assumption_ids
+        ]
+        query_tokens = tokenize(
+            " ".join(
+                [
+                    topic,
+                    *[
+                        " ".join(
+                            [
+                                assumption["title"],
+                                assumption["claim"],
+                                " ".join(assumption["keywords"]),
+                            ]
+                        )
+                        for assumption in related_assumptions
+                    ],
+                ]
+            )
+        )
+        declared.append(
+            CanonMatch(
+                path=path,
+                title=document.title,
+                reason=(
+                    "declared canon source for " + ", ".join(sorted(assumption_ids))
+                ),
+                score=10_000,
+                excerpt=relevant_excerpt(document.content, query_tokens),
+                headings=extract_headings(document.content),
+                assumption_ids=tuple(sorted(assumption_ids)),
+            )
+        )
+
+    discovered = nearby_canon(topic, lane, documents, limit=limit)
+    selected = list(declared)
+    seen = {match.path for match in declared}
+    for match in discovered:
+        if match.path in seen:
+            continue
+        selected.append(match)
+        seen.add(match.path)
+        if len(selected) >= max(limit, len(declared)):
+            break
+    return selected
 
 
 def load_assumptions(path: Path = DEFAULT_ASSUMPTIONS_PATH) -> list[dict[str, Any]]:
@@ -425,6 +566,8 @@ def build_prompt(
             "path": match.path,
             "title": match.title,
             "why_nearby": match.reason,
+            "declared_for_assumptions": list(match.assumption_ids),
+            "existing_headings": list(match.headings),
             "excerpt": match.excerpt,
         }
         for match in canon_matches
@@ -443,7 +586,11 @@ Keep these boundaries:
   source must have the exact URL surfaced by web research.
 - Assess only the supplied assumption IDs. Use "insufficient-evidence" when the
   available evidence does not justify a directional verdict.
-- Recommend canon review but never claim to modify canon.
+- Turn canon review into an implementation plan: use only supplied repository
+  paths, anchor each proposal to an exact supplied heading, cite the assumption
+  and evidence IDs, and state concrete edit steps and conflicts.
+- Prefer each assumption's declared canon sources before adding discovered
+  related files. Never claim to modify canon.
 - Include contradictory evidence and meaningful uncertainty.
 - Return only data conforming to the provided structured-output schema."""
     user = f"""Research topic: {topic}
@@ -461,8 +608,9 @@ Nearby PostSingularity canon:
 {json.dumps(canon_payload, indent=2)}
 
 Produce a decision-useful research brief. Explain what changed, how strong the
-evidence is, which assumptions are strengthened or weakened, what implications
-follow for the storyworld, and what should be watched next."""
+evidence is, which assumptions are strengthened or weakened, and exactly where
+and how accepted evidence could be implemented in the repository. Generic
+instructions such as "revise this file" are insufficient."""
     return [
         {"role": "system", "content": system},
         {"role": "user", "content": user},
@@ -499,6 +647,7 @@ def extract_native_citations(response: Any) -> set[str]:
 def validate_brief(
     brief: ResearchBrief,
     selected_assumptions: Sequence[dict[str, Any]],
+    canon_matches: Sequence[CanonMatch] = (),
 ) -> None:
     source_ids = [source.id for source in brief.sources]
     if not source_ids:
@@ -521,6 +670,39 @@ def validate_brief(
             raise ValueError(
                 f"{assessment.assumption_id} cites unknown sources: {sorted(missing)}"
             )
+
+    allowed_canon = {match.path: match for match in canon_matches}
+    seen_targets: set[tuple[str, str]] = set()
+    for implication in brief.canon_implications:
+        if allowed_canon and implication.path not in allowed_canon:
+            raise ValueError(
+                f"Canon plan references a file outside supplied context: {implication.path}"
+            )
+        unknown_assumptions = set(implication.assumption_ids) - selected_ids
+        if unknown_assumptions:
+            raise ValueError(
+                "Canon plan references unselected assumptions: "
+                f"{sorted(unknown_assumptions)}"
+            )
+        missing_sources = set(implication.source_ids) - known_sources
+        if missing_sources:
+            raise ValueError(
+                f"Canon plan for {implication.path} cites unknown sources: "
+                f"{sorted(missing_sources)}"
+            )
+        if allowed_canon:
+            headings = {
+                heading.casefold() for heading in allowed_canon[implication.path].headings
+            }
+            if implication.target_heading.casefold() not in headings:
+                raise ValueError(
+                    f"Unknown target heading in {implication.path}: "
+                    f"{implication.target_heading}"
+                )
+        target = (implication.path, implication.target_heading.casefold())
+        if target in seen_targets:
+            raise ValueError(f"Duplicate canon implementation target: {target}")
+        seen_targets.add(target)
 
 
 def run_live_research(
@@ -558,7 +740,7 @@ def run_live_research(
     if response.output_parsed is None:
         raise RuntimeError("The model returned no parsed research brief")
     brief = response.output_parsed
-    validate_brief(brief, assumptions)
+    validate_brief(brief, assumptions, canon_matches)
     return brief, extract_native_citations(response)
 
 
@@ -572,7 +754,13 @@ def build_mock_brief(
 ) -> ResearchBrief:
     """Build deterministic synthetic data for formatting and workflow tests."""
     assumption = assumptions[0]
-    canon_path = canon_matches[0].path if canon_matches else assumption["canon_sources"][0]
+    canon_match = canon_matches[0] if canon_matches else None
+    canon_path = canon_match.path if canon_match else assumption["canon_sources"][0]
+    target_heading = (
+        canon_match.headings[0]
+        if canon_match and canon_match.headings
+        else "PostSingularity"
+    )
     return ResearchBrief(
         title=f"Mock research brief: {topic}",
         executive_summary=(
@@ -607,8 +795,23 @@ def build_mock_brief(
         canon_implications=[
             CanonImplication(
                 path=canon_path,
-                implication="The pipeline can map a report to nearby canon.",
+                target_heading=target_heading,
+                assumption_ids=[assumption["id"]],
+                source_ids=["S1"],
+                relationship="no-material-effect",
                 recommendation="no-change",
+                priority="watch",
+                rationale="Mock evidence cannot justify a repository change.",
+                proposed_change=(
+                    "Leave the target section unchanged until live evidence is reviewed."
+                ),
+                implementation_steps=[
+                    "Run a live source-grounded research pass.",
+                    "Reassess this exact section after human source verification.",
+                ],
+                dependencies_or_conflicts=[
+                    "Synthetic fixtures must never be treated as canon evidence."
+                ],
             )
         ],
         uncertainties=["All substantive content in this report is synthetic."],
@@ -706,15 +909,41 @@ def format_memo(
             ]
         )
 
-    lines.extend(["## Canon Mapping", ""])
+    lines.extend(["## Canon Implementation Plan", ""])
     if brief.canon_implications:
         for implication in brief.canon_implications:
+            assumptions = ", ".join(
+                f"`{assumption_id}`" for assumption_id in implication.assumption_ids
+            )
+            citations = ", ".join(
+                f"`{source_id}`" for source_id in implication.source_ids
+            )
             lines.extend(
                 [
-                    f"### `{implication.path}`",
+                    f"### `{implication.path}` -> {implication.target_heading}",
                     "",
+                    f"- Priority: **{implication.priority}**",
                     f"- Recommendation: **{implication.recommendation}**",
-                    f"- Implication: {implication.implication}",
+                    f"- Evidence relationship: **{implication.relationship}**",
+                    f"- Assumptions: {assumptions or 'None'}",
+                    f"- Sources: {citations or 'None'}",
+                    f"- Why this location: {implication.rationale}",
+                    f"- Proposed change: {implication.proposed_change}",
+                    "- Implementation steps:",
+                    *[
+                        f"  {index}. {step}"
+                        for index, step in enumerate(
+                            implication.implementation_steps, start=1
+                        )
+                    ],
+                    "- Dependencies or conflicts:",
+                    *(
+                        [
+                            f"  - {item}"
+                            for item in implication.dependencies_or_conflicts
+                        ]
+                        or ["  - None identified."]
+                    ),
                     "",
                 ]
             )
@@ -755,7 +984,9 @@ def format_memo(
             "- [ ] Confirm demonstrations are not described as deployments.",
             "- [ ] Check for contradictory evidence and missing primary sources.",
             "- [ ] Accept, revise, or reject each proposed assumption verdict.",
-            "- [ ] Decide whether any canon change should enter the contribution workflow.",
+            "- [ ] Verify every target file and heading still exists.",
+            "- [ ] Accept, revise, or reject each proposed repository edit.",
+            "- [ ] Move accepted changes through the normal contribution workflow.",
             "",
             "```json",
             json.dumps(
@@ -889,7 +1120,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             assumptions,
             requested_ids=args.assumption,
         )
-        canon_matches = nearby_canon(topic, lane, load_canon_files(), limit=6)
+        canon_matches = select_canon_context(
+            topic,
+            lane,
+            load_canon_files(),
+            selected,
+        )
 
         if args.mock:
             brief = build_mock_brief(
@@ -900,6 +1136,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 run_date,
                 args.lookback_days,
             )
+            validate_brief(brief, selected, canon_matches)
             native_citations: set[str] = set()
         else:
             brief, native_citations = run_live_research(

--- a/tools/research_crew.py
+++ b/tools/research_crew.py
@@ -26,9 +26,9 @@ from tools.research_agent import (
     infer_lane,
     load_assumptions,
     load_canon_files,
-    nearby_canon,
     scheduled_topic,
     select_assumptions,
+    select_canon_context,
     validate_brief,
     write_memo,
 )
@@ -59,11 +59,19 @@ class AuditedEvidence(StrictModel):
 
 class AnalysisPacket(StrictModel):
     assumption_assessments: list[AssumptionAssessment]
-    canon_implications: list[CanonImplication]
     uncertainties: list[str]
     watchlist: list[str]
     daily_change_summary: str = Field(
         description="What is meaningfully new since the prior state, without hype"
+    )
+
+
+class ImplementationPacket(StrictModel):
+    canon_implications: list[CanonImplication]
+    coverage_notes: list[str] = Field(
+        description=(
+            "Explanation for assessed assumptions that do not warrant a repository edit"
+        )
     )
 
 
@@ -97,6 +105,8 @@ def _canon_context_json(canon_matches: Sequence[Any]) -> str:
                 "path": match.path,
                 "title": match.title,
                 "why_nearby": match.reason,
+                "declared_for_assumptions": list(match.assumption_ids),
+                "existing_headings": list(match.headings),
                 "excerpt": match.excerpt,
             }
             for match in canon_matches
@@ -205,6 +215,23 @@ def build_research_crew(
         verbose=verbose,
         max_iter=6,
     )
+    repository_mapper = Agent(
+        role="PostSingularity Repository Implementation Mapper",
+        goal=(
+            "Translate reviewed evidence into exact, actionable repository edit "
+            "plans tied to existing files, headings, assumptions, and source IDs."
+        ),
+        backstory=(
+            "You are the storyworld's information architect and change planner. "
+            "You understand that naming a nearby file is not enough: every proposal "
+            "must identify the exact anchor, explain why it belongs there, describe "
+            "the edit, and surface dependencies or canon conflicts."
+        ),
+        llm=analysis_llm,
+        allow_delegation=False,
+        verbose=verbose,
+        max_iter=6,
+    )
     canon_editor = Agent(
         role="Research Brief and Canon Review Editor",
         goal=(
@@ -286,21 +313,119 @@ claims that should be excluded. Do not invent replacement sources or URLs.""",
         description=f"""Assess every supplied assumption ID against the audited
 evidence. Return exactly one assessment per assumption. A lack of evidence must
 produce an insufficient-evidence verdict, not omission. Separate the real-world
-implication from the PostSingularity implication. Recommend only monitor,
-revise, debate, or no-change for canon.
+implication from the PostSingularity implication. Concentrate on the strength
+and direction of evidence; the repository mapper will decide where changes belong.
 
 Tracked assumptions:
-{assumption_json}
-
-Nearby canon:
-{canon_json}""",
+{assumption_json}""",
         expected_output=(
-            "An AnalysisPacket covering every selected assumption, canon review "
-            "implications, uncertainty, a watchlist, and a sober daily change summary."
+            "An AnalysisPacket covering every selected assumption, uncertainty, "
+            "a watchlist, and a sober daily change summary."
         ),
         agent=assumption_analyst,
         context=[audit_task],
         output_pydantic=AnalysisPacket,
+    )
+
+    allowed_headings = {
+        match.path: {heading.casefold() for heading in match.headings}
+        for match in canon_matches
+    }
+    selected_assumption_ids = {assumption["id"] for assumption in assumptions}
+
+    def implementation_guardrail(task_output):
+        packet = task_output.pydantic
+        if not isinstance(packet, ImplementationPacket):
+            return False, "Return a valid typed ImplementationPacket."
+
+        known_source_ids: set[str] = set()
+        if audit_task.output and isinstance(audit_task.output.pydantic, AuditedEvidence):
+            known_source_ids = {
+                source.id for source in audit_task.output.pydantic.sources
+            }
+
+        errors: list[str] = []
+        covered_assumptions: set[str] = set()
+        for item in packet.canon_implications:
+            if item.path not in allowed_headings:
+                errors.append(f"Unknown repository path: {item.path}")
+                continue
+            if item.target_heading.casefold() not in allowed_headings[item.path]:
+                errors.append(
+                    f"Unknown heading in {item.path}: {item.target_heading}"
+                )
+            unknown_assumptions = (
+                set(item.assumption_ids) - selected_assumption_ids
+            )
+            if unknown_assumptions:
+                errors.append(
+                    f"Unselected assumptions: {sorted(unknown_assumptions)}"
+                )
+            covered_assumptions.update(item.assumption_ids)
+            unknown_sources = set(item.source_ids) - known_source_ids
+            if unknown_sources:
+                errors.append(f"Unknown source IDs: {sorted(unknown_sources)}")
+            if not item.implementation_steps:
+                errors.append(
+                    f"{item.path} -> {item.target_heading} needs implementation steps"
+                )
+
+        directional_ids: set[str] = set()
+        if analysis_task.output and isinstance(
+            analysis_task.output.pydantic, AnalysisPacket
+        ):
+            directional_ids = {
+                assessment.assumption_id
+                for assessment in analysis_task.output.pydantic.assumption_assessments
+                if assessment.verdict
+                in {"strengthened", "weakened", "contradicted", "mixed"}
+            }
+        uncovered = directional_ids - covered_assumptions
+        if uncovered:
+            errors.append(
+                "Directional assumption assessments need implementation items: "
+                f"{sorted(uncovered)}"
+            )
+
+        if errors:
+            return False, "Repository mapping errors: " + "; ".join(errors)
+        return True, task_output
+
+    mapping_task = Task(
+        description=f"""Convert the audited evidence and assumption assessments
+into an actionable repository implementation plan.
+
+Repository context:
+{canon_json}
+
+Requirements:
+- Prefer files declared for the affected assumption before discovered related files.
+- Use only repository paths supplied above.
+- Copy target_heading exactly from that file's existing_headings list. Use the
+  closest existing heading as the insertion anchor when proposing a new subsection.
+- Cite the exact assumption IDs and audited source IDs that justify each plan item.
+- State whether evidence supports, challenges, qualifies, extends, or has no
+  material effect on the target content.
+- proposed_change must describe the actual content to add, remove, or qualify.
+  Generic language such as "update this file to reflect the evidence" is invalid.
+- implementation_steps must explain placement, cross-references, metadata or index
+  effects, and review order where relevant.
+- dependencies_or_conflicts must identify related canon claims, chronology,
+  terminology, or narrative consequences that a human reviewer should reconcile.
+- Give high priority only to strong, material contradictions or time-sensitive
+  updates. Use no-change/watch when the evidence is insufficient.
+- Cover every directional or mixed assumption assessment with at least one plan
+  item. Explain non-actionable assessments in coverage_notes.
+- Do not edit files and do not claim that any proposal has been accepted.""",
+        expected_output=(
+            "An ImplementationPacket containing exact file-and-heading edit plans "
+            "plus coverage notes for assumptions that do not warrant a change."
+        ),
+        agent=repository_mapper,
+        context=[audit_task, analysis_task],
+        output_pydantic=ImplementationPacket,
+        guardrail=implementation_guardrail,
+        guardrail_max_retries=2,
     )
     editor_task = Task(
         description=f"""Assemble the final structured ResearchBrief from the
@@ -313,9 +438,12 @@ Research window: {start_date.isoformat()} through {run_date.isoformat()}
 Requirements:
 - Preserve the auditor's exact source IDs and URLs.
 - Include the audited developments and every assumption assessment.
+- Preserve the repository mapper's implementation items without weakening their
+  file, heading, evidence, proposed-change, dependency, or priority detail.
+- Carry repository-mapper coverage notes into uncertainties when no edit is warranted.
 - Include contradictions and excluded-claim concerns in uncertainties.
 - Make the title and executive summary decision-useful, not promotional.
-- Use only these nearby canon paths for canon implications:
+- Use only these repository paths and headings for canon implications:
 {canon_json}
 - Do not modify canon or claim that the registry was updated.""",
         expected_output=(
@@ -323,7 +451,7 @@ Requirements:
             "validation and Markdown rendering."
         ),
         agent=canon_editor,
-        context=[audit_task, analysis_task],
+        context=[audit_task, analysis_task, mapping_task],
         output_pydantic=ResearchBrief,
     )
 
@@ -333,6 +461,7 @@ Requirements:
             counterevidence_scout,
             evidence_auditor,
             assumption_analyst,
+            repository_mapper,
             canon_editor,
         ],
         tasks=[
@@ -340,6 +469,7 @@ Requirements:
             counterevidence_task,
             audit_task,
             analysis_task,
+            mapping_task,
             editor_task,
         ],
         process=Process.sequential,
@@ -381,7 +511,7 @@ def run_crew_research(
         brief = ResearchBrief.model_validate(editor_task.output.pydantic)
     else:
         brief = ResearchBrief.model_validate_json(editor_task.output.raw)
-    validate_brief(brief, assumptions)
+    validate_brief(brief, assumptions, canon_matches)
     return brief
 
 
@@ -420,7 +550,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             assumptions,
             requested_ids=args.assumption,
         )
-        canon_matches = nearby_canon(topic, lane, load_canon_files(), limit=6)
+        canon_matches = select_canon_context(
+            topic,
+            lane,
+            load_canon_files(),
+            selected,
+        )
 
         if args.mock:
             brief = build_mock_brief(
@@ -431,6 +566,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 run_date,
                 args.lookback_days,
             )
+            validate_brief(brief, selected, canon_matches)
         else:
             brief = run_crew_research(
                 topic,


### PR DESCRIPTION
﻿## What changed

- Expands canon context from six keyword-nearby files to a deterministic set that always includes every selected assumption's declared canon sources plus discovered related files.
- Supplies exact existing headings and relevant section excerpts instead of only each file's opening text.
- Adds a sixth CrewAI role: PostSingularity Repository Implementation Mapper.
- Adds a typed implementation plan with target file, exact heading anchor, assumption IDs, source IDs, evidence relationship, priority, rationale, proposed content change, ordered implementation steps, and dependencies/conflicts.
- Adds a guardrail that retries invalid mapping output when the model invents paths/headings, cites unknown sources, or leaves directional assessments unmapped.
- Adds final deterministic validation and a more actionable Markdown review format.

## Why

The first live brief researched and assessed the evidence well, but its canon mapping mostly named nearby files and generic recommendations. It did not reliably answer where an accepted finding belonged in the repository or how a reviewer should implement it.

## Impact

Future briefs will remain non-canonical, but their review layer will function as a concrete repository change plan. Humans can verify sources, evaluate a proposed edit in its exact existing context, see related canon dependencies, and move accepted changes into normal contribution work without rediscovering the repository structure.

## Validation

- 16 tests passed against CrewAI 1.15.7
- Six-agent and six-task crew construction passed
- Assumption-declared canon coverage regression passed
- Invented-heading rejection regression passed
- Expanded mock implementation plan rendered successfully
- Python compilation passed
- Repository metadata validation passed
- Cohesion remains 99.24% with one pre-existing cycle-reference warning

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/techninja828/postsingularity/pull/47" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->